### PR TITLE
Refine payment and Wompi checkout configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ staticfiles/
 migrations/
 styles.css
 theme/
+migrations/

--- a/project/orders/admin.py
+++ b/project/orders/admin.py
@@ -24,7 +24,7 @@ class OrderAdmin(ModelAdmin):
         'created_at', 'delivery_city'
     )
     search_fields = ('order_number', 'customer_name', 'customer_phone', 'customer_email')
-    readonly_fields = ('order_number', 'subtotal', 'total', 'created_at', 'updated_at')
+    readonly_fields = ('order_number', 'subtotal', 'total', 'created_at', 'updated_at', 'payment_reference')
     inlines = [OrderItemInline]
     date_hierarchy = 'desired_date'
     
@@ -46,7 +46,7 @@ class OrderAdmin(ModelAdmin):
             'fields': ('desired_date', 'desired_time', 'estimated_delivery', 'created_at', 'updated_at')
         }),
         ('Pagos', {
-            'fields': ('payment_status', 'payment_method')
+            'fields': ('payment_status', 'payment_method', 'payment_reference')
         }),
         ('Totales', {
             'fields': ('subtotal', 'delivery_fee', 'total')
@@ -317,7 +317,11 @@ class BusinessSettingsAdmin(ModelAdmin):
             'fields': ('delivery_start_time', 'delivery_end_time')
         }),
         ('Métodos de Pago', {
-            'fields': ('accept_cash', 'accept_transfer', 'accept_card', 'accept_pse')
+            'fields': ('accept_cash', 'accept_wompi')
+        }),
+        ('Configuración Wompi', {
+            'fields': ('wompi_environment', 'wompi_public_key', 'wompi_private_key', 'wompi_integrity_key'),
+            'description': 'Configura las llaves proporcionadas por Wompi para habilitar pagos en línea.'
         }),
     )
     

--- a/project/orders/migrations/0008_wompi_integration.py
+++ b/project/orders/migrations/0008_wompi_integration.py
@@ -1,0 +1,59 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('orders', '0007_remove_ordermodificationrequest_status_and_more'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='order',
+            name='payment_reference',
+            field=models.CharField(
+                blank=True,
+                help_text='Identificador de la transacción en la pasarela de pago',
+                max_length=120,
+                verbose_name='Referencia de pago',
+            ),
+        ),
+        migrations.AddField(
+            model_name='businesssettings',
+            name='accept_wompi',
+            field=models.BooleanField(
+                default=False,
+                verbose_name='Aceptar pagos con Wompi',
+            ),
+        ),
+        migrations.AddField(
+            model_name='businesssettings',
+            name='wompi_environment',
+            field=models.CharField(
+                choices=[('test', 'Sandbox/Pruebas'), ('production', 'Producción')],
+                default='test',
+                max_length=20,
+                verbose_name='Entorno de Wompi',
+            ),
+        ),
+        migrations.AddField(
+            model_name='businesssettings',
+            name='wompi_private_key',
+            field=models.CharField(
+                blank=True,
+                help_text='Llave privada provista por Wompi para consultar transacciones',
+                max_length=120,
+                verbose_name='Llave privada Wompi',
+            ),
+        ),
+        migrations.AddField(
+            model_name='businesssettings',
+            name='wompi_public_key',
+            field=models.CharField(
+                blank=True,
+                help_text='Llave pública provista por Wompi (pub_test_xxx o pub_prod_xxx)',
+                max_length=120,
+                verbose_name='Llave pública Wompi',
+            ),
+        ),
+    ]

--- a/project/orders/migrations/0009_update_payment_methods.py
+++ b/project/orders/migrations/0009_update_payment_methods.py
@@ -1,0 +1,41 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('orders', '0008_wompi_integration'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='businesssettings',
+            name='accept_card',
+        ),
+        migrations.RemoveField(
+            model_name='businesssettings',
+            name='accept_pse',
+        ),
+        migrations.RemoveField(
+            model_name='businesssettings',
+            name='accept_transfer',
+        ),
+        migrations.AlterField(
+            model_name='businesssettings',
+            name='accept_wompi',
+            field=models.BooleanField(
+                default=True,
+                verbose_name='Aceptar pagos con Wompi',
+            ),
+        ),
+        migrations.AddField(
+            model_name='businesssettings',
+            name='wompi_integrity_key',
+            field=models.CharField(
+                blank=True,
+                help_text='Llave usada para firmar los pagos iniciados desde el widget de Wompi',
+                max_length=120,
+                verbose_name='Llave de integridad Wompi',
+            ),
+        ),
+    ]

--- a/project/orders/models.py
+++ b/project/orders/models.py
@@ -40,6 +40,7 @@ class Order(models.Model):
         ('transfer', 'Transferencia'),
         ('card', 'Tarjeta'),
         ('pse', 'PSE'),
+        ('wompi', 'Wompi'),
         ('pay_later', 'Pagar después'),
     ]
     
@@ -77,6 +78,12 @@ class Order(models.Model):
     # Información de pago
     payment_status = models.CharField(max_length=20, choices=PAYMENT_STATUS, default='pending', verbose_name='Estado del pago')
     payment_method = models.CharField(max_length=20, choices=PAYMENT_METHOD, blank=True, verbose_name='Método de pago')
+    payment_reference = models.CharField(
+        max_length=120,
+        blank=True,
+        verbose_name='Referencia de pago',
+        help_text='Identificador de la transacción en la pasarela de pago'
+    )
     
     # Notas y comentarios
     notes = models.TextField(blank=True, verbose_name='Notas del cliente')
@@ -340,9 +347,32 @@ class BusinessSettings(models.Model):
     
     # Configuraciones de pago
     accept_cash = models.BooleanField(default=True, verbose_name='Acepta efectivo')
-    accept_transfer = models.BooleanField(default=True, verbose_name='Acepta transferencia')
-    accept_card = models.BooleanField(default=True, verbose_name='Acepta tarjeta')
-    accept_pse = models.BooleanField(default=False, verbose_name='Acepta PSE')
+    accept_wompi = models.BooleanField(default=True, verbose_name='Aceptar pagos con Wompi')
+
+    wompi_public_key = models.CharField(
+        max_length=120,
+        blank=True,
+        verbose_name='Llave pública Wompi',
+        help_text='Llave pública provista por Wompi (pub_test_xxx o pub_prod_xxx)'
+    )
+    wompi_private_key = models.CharField(
+        max_length=120,
+        blank=True,
+        verbose_name='Llave privada Wompi',
+        help_text='Llave privada provista por Wompi para consultar transacciones'
+    )
+    wompi_integrity_key = models.CharField(
+        max_length=120,
+        blank=True,
+        verbose_name='Llave de integridad Wompi',
+        help_text='Llave usada para firmar los pagos iniciados desde el widget de Wompi'
+    )
+    wompi_environment = models.CharField(
+        max_length=20,
+        choices=[('test', 'Sandbox/Pruebas'), ('production', 'Producción')],
+        default='test',
+        verbose_name='Entorno de Wompi'
+    )
     
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
@@ -369,6 +399,7 @@ class BusinessSettings(models.Model):
                 department='Casanare',
                 delivery_cost=Decimal('5000'),
                 modification_time_limit_hours=4,  # ✅ AGREGAR valores por defecto
-                cancellation_time_limit_days=1
+                cancellation_time_limit_days=1,
+                accept_wompi=True,
             )
         return settings

--- a/project/orders/services/__init__.py
+++ b/project/orders/services/__init__.py
@@ -1,0 +1,15 @@
+"""Servicios y utilidades para integraciones externas del módulo de pedidos."""
+
+from .wompi import (
+    WompiAPIError,
+    get_acceptance_information,
+    get_transaction_information,
+    get_wompi_base_url,
+)
+
+__all__ = [
+    'WompiAPIError',
+    'get_acceptance_information',
+    'get_transaction_information',
+    'get_wompi_base_url',
+]

--- a/project/orders/services/__init__.py
+++ b/project/orders/services/__init__.py
@@ -5,6 +5,7 @@ from .wompi import (
     get_acceptance_information,
     get_transaction_information,
     get_wompi_base_url,
+    split_phone_number,
 )
 
 __all__ = [
@@ -12,4 +13,5 @@ __all__ = [
     'get_acceptance_information',
     'get_transaction_information',
     'get_wompi_base_url',
+    'split_phone_number',
 ]

--- a/project/orders/services/wompi.py
+++ b/project/orders/services/wompi.py
@@ -1,0 +1,96 @@
+"""Funciones auxiliares para la integración con la pasarela Wompi."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+from urllib import error, request
+
+
+class WompiAPIError(Exception):
+    """Error genérico al comunicarse con los servicios de Wompi."""
+
+
+@dataclass
+class WompiEnvironment:
+    """Representa las URLs base según el entorno configurado."""
+
+    api_url: str
+    checkout_domain: str
+
+
+def get_wompi_base_url(environment: str) -> WompiEnvironment:
+    """Obtiene las URLs base para el entorno configurado."""
+
+    environment = (environment or 'test').lower()
+    if environment == 'production':
+        return WompiEnvironment(
+            api_url='https://production.wompi.co',
+            checkout_domain='prod',
+        )
+    return WompiEnvironment(
+        api_url='https://sandbox.wompi.co',
+        checkout_domain='test',
+    )
+
+
+def _perform_get(url: str, *, headers: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
+    """Realiza un GET simple y devuelve el JSON de respuesta."""
+
+    req = request.Request(url, headers=headers or {})
+    try:
+        with request.urlopen(req, timeout=15) as response:
+            payload = response.read().decode('utf-8')
+    except error.HTTPError as exc:  # pragma: no cover - controlamos el mensaje
+        raise WompiAPIError(
+            f"Wompi respondió con un error HTTP {exc.code}: {exc.reason}"
+        ) from exc
+    except error.URLError as exc:  # pragma: no cover - dependerá de la red
+        raise WompiAPIError('No fue posible conectarse con Wompi. Intenta nuevamente.') from exc
+
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError as exc:  # pragma: no cover - respuesta inesperada
+        raise WompiAPIError('La respuesta de Wompi no es válida.') from exc
+
+
+def get_acceptance_information(public_key: str, environment: str) -> Dict[str, Any]:
+    """Obtiene información de aceptación (términos y token) para el comercio."""
+
+    if not public_key:
+        raise WompiAPIError('No se configuró la llave pública de Wompi.')
+
+    env = get_wompi_base_url(environment)
+    data = _perform_get(f"{env.api_url}/v1/merchants/{public_key}")
+    return data.get('data', {})
+
+
+def get_transaction_information(
+    transaction_id: str,
+    environment: str,
+    *,
+    public_key: Optional[str] = None,
+    private_key: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Consulta el estado de una transacción específica."""
+
+    if not transaction_id:
+        raise WompiAPIError('No se proporcionó el identificador de la transacción.')
+
+    env = get_wompi_base_url(environment)
+    headers: Dict[str, str] = {}
+    token = private_key or public_key
+    if token:
+        headers['Authorization'] = f'Bearer {token}'
+
+    data = _perform_get(f"{env.api_url}/v1/transactions/{transaction_id}", headers=headers)
+    return data.get('data', {})
+
+
+__all__ = [
+    'WompiAPIError',
+    'get_acceptance_information',
+    'get_transaction_information',
+    'get_wompi_base_url',
+]

--- a/project/orders/services/wompi.py
+++ b/project/orders/services/wompi.py
@@ -14,10 +14,10 @@ class WompiAPIError(Exception):
 
 @dataclass
 class WompiEnvironment:
-    """Representa las URLs base según el entorno configurado."""
+    """Representa la configuración base según el entorno."""
 
     api_url: str
-    checkout_domain: str
+    widget_js_url: str
 
 
 def get_wompi_base_url(environment: str) -> WompiEnvironment:
@@ -27,11 +27,11 @@ def get_wompi_base_url(environment: str) -> WompiEnvironment:
     if environment == 'production':
         return WompiEnvironment(
             api_url='https://production.wompi.co',
-            checkout_domain='prod',
+            widget_js_url='https://checkout.wompi.co/widget.js',
         )
     return WompiEnvironment(
         api_url='https://sandbox.wompi.co',
-        checkout_domain='test',
+        widget_js_url='https://sandbox.checkout.wompi.co/widget.js',
     )
 
 
@@ -58,6 +58,7 @@ def _perform_get(url: str, *, headers: Optional[Dict[str, str]] = None) -> Dict[
 def get_acceptance_information(public_key: str, environment: str) -> Dict[str, Any]:
     """Obtiene información de aceptación (términos y token) para el comercio."""
 
+    public_key = (public_key or '').strip()
     if not public_key:
         raise WompiAPIError('No se configuró la llave pública de Wompi.')
 
@@ -75,12 +76,13 @@ def get_transaction_information(
 ) -> Dict[str, Any]:
     """Consulta el estado de una transacción específica."""
 
+    transaction_id = (transaction_id or '').strip()
     if not transaction_id:
         raise WompiAPIError('No se proporcionó el identificador de la transacción.')
 
     env = get_wompi_base_url(environment)
     headers: Dict[str, str] = {}
-    token = private_key or public_key
+    token = (private_key or public_key or '').strip()
     if token:
         headers['Authorization'] = f'Bearer {token}'
 

--- a/project/orders/services/wompi.py
+++ b/project/orders/services/wompi.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 from urllib import error, request
 
 
@@ -18,6 +18,7 @@ class WompiEnvironment:
 
     api_url: str
     widget_js_url: str
+    widget_js_urls: Tuple[str, ...]
 
 
 def get_wompi_base_url(environment: str) -> WompiEnvironment:
@@ -28,10 +29,18 @@ def get_wompi_base_url(environment: str) -> WompiEnvironment:
         return WompiEnvironment(
             api_url='https://production.wompi.co',
             widget_js_url='https://checkout.wompi.co/widget.js',
+            widget_js_urls=(
+                'https://checkout.wompi.co/widget.js',
+                'https://cdn.wompi.co/widget.js',
+            ),
         )
     return WompiEnvironment(
         api_url='https://sandbox.wompi.co',
-        widget_js_url='https://sandbox.checkout.wompi.co/widget.js',
+        widget_js_url='https://checkout.wompi.co/widget.js',
+        widget_js_urls=(
+            'https://checkout.wompi.co/widget.js',
+            'https://cdn.wompi.co/widget.js',
+        ),
     )
 
 

--- a/project/orders/templates/orders/step3.html
+++ b/project/orders/templates/orders/step3.html
@@ -111,68 +111,34 @@
                 </h3>
                 
                 <div class="mt-4 space-y-3">
-                    <!-- Efectivo -->
+                    {% for method in payment_methods %}
                     <label class="radio-option">
-                        <input type="radio" name="payment_method" value="cash" 
-                               class="radio-option-input peer" checked>
-                        <div class="payment-option-card peer-checked:border-green-500 peer-checked:bg-green-50">
+                        <input type="radio" name="payment_method" value="{{ method.value }}"
+                               class="radio-option-input peer"
+                               {% if method.value == default_payment_method %}checked{% elif not default_payment_method and forloop.first %}checked{% endif %}>
+                        <div class="payment-option-card {{ method.card_classes }}">
                             <div class="payment-option-content">
                                 <div class="payment-option-icon">
-                                    <span class="material-icons text-green-600">payments</span>
+                                    <span class="material-icons {{ method.icon_classes }}">{{ method.icon }}</span>
                                 </div>
                                 <div class="payment-option-text">
-                                    <div class="payment-option-title">Efectivo</div>
-                                    <div class="payment-option-description">Pago al recibir</div>
+                                    <div class="payment-option-title">{{ method.label }}</div>
+                                    <div class="payment-option-description">{{ method.description }}</div>
                                 </div>
                             </div>
                         </div>
                     </label>
-
-                    <!-- Transferencia -->
-                    <label class="radio-option">
-                        <input type="radio" name="payment_method" value="transfer" 
-                               class="radio-option-input peer">
-                        <div class="payment-option-card peer-checked:border-blue-500 peer-checked:bg-blue-50">
-                            <div class="payment-option-content">
-                                <div class="payment-option-icon">
-                                    <span class="material-icons text-blue-600">account_balance</span>
-                                </div>
-                                <div class="payment-option-text">
-                                    <div class="payment-option-title">Transferencia</div>
-                                    <div class="payment-option-description">Bancolombia, Nequi</div>
-                                </div>
-                            </div>
-                        </div>
-                    </label>
-
-                    <!-- PSE -->
-                    <label class="radio-option">
-                        <input type="radio" name="payment_method" value="pse" 
-                               class="radio-option-input peer">
-                        <div class="payment-option-card peer-checked:border-purple-500 peer-checked:bg-purple-50">
-                            <div class="payment-option-content">
-                                <div class="payment-option-icon">
-                                    <span class="material-icons text-purple-600">credit_card</span>
-                                </div>
-                                <div class="payment-option-text">
-                                    <div class="payment-option-title">PSE</div>
-                                    <div class="payment-option-description">Pago seguro en línea</div>
-                                </div>
-                            </div>
-                        </div>
-                    </label>
+                    {% empty %}
+                    <p class="text-sm text-gray-600">No hay métodos de pago disponibles en este momento.</p>
+                    {% endfor %}
 
                     <!-- Información del método seleccionado -->
                     <div id="payment-info" class="mt-4 p-3 bg-gray-50 rounded-lg text-xs text-gray-600">
-                        <div id="cash-info">
-                            <p><strong>Efectivo:</strong> Paga al recibir tu pedido. Ten el monto exacto disponible.</p>
+                        {% for method in payment_methods %}
+                        <div data-payment-info="{{ method.value }}" style="display: none;">
+                            <p><strong>{{ method.label }}:</strong> {{ method.info }}</p>
                         </div>
-                        <div id="transfer-info" style="display: none;">
-                            <p><strong>Transferencia:</strong> Recibirás los datos bancarios por WhatsApp para completar el pago.</p>
-                        </div>
-                        <div id="pse-info" style="display: none;">
-                            <p><strong>PSE:</strong> Serás redirigido a la plataforma de tu banco para completar el pago.</p>
-                        </div>
+                        {% endfor %}
                     </div>
                 </div>
             </div>
@@ -206,8 +172,9 @@ document.addEventListener('DOMContentLoaded', function() {
 
         const selectedProducts = {{ selected_products|safe }};
         const settings = {
-            minimumOrder: {{ settings.minimum_order_amount|default:20000|floatformat:0 }},
-            freeDeliveryThreshold: {{ settings.free_delivery_threshold|default:50000|floatformat:0 }}
+            minimumOrder: Number('{{ settings.minimum_order_amount|default:20000|floatformat:0 }}'),
+            freeDeliveryThreshold: Number('{{ settings.free_delivery_threshold|default:50000|floatformat:0 }}'),
+            deliveryCost: Number('{{ settings.delivery_cost|default:0|floatformat:0 }}')
         };
 
         // Llenar información básica
@@ -308,18 +275,32 @@ document.addEventListener('DOMContentLoaded', function() {
 
     function setupPaymentMethodChange() {
         const radios = document.querySelectorAll('input[name="payment_method"]');
+        const infoSections = document.querySelectorAll('[data-payment-info]');
+
+        function hideAllPaymentInfos() {
+            infoSections.forEach(section => {
+                section.style.display = 'none';
+            });
+        }
+
         radios.forEach(radio => {
             radio.addEventListener('change', function() {
-                // Ocultar todas las infos
-                document.getElementById('cash-info').style.display = 'none';
-                document.getElementById('transfer-info').style.display = 'none';
-                document.getElementById('pse-info').style.display = 'none';
-                
-                // Mostrar la info correspondiente
-                document.getElementById(this.value + '-info').style.display = 'block';
-        
+                hideAllPaymentInfos();
+                const target = document.querySelector(`[data-payment-info="${this.value}"]`);
+                if (target) {
+                    target.style.display = 'block';
+                }
             });
         });
+
+        hideAllPaymentInfos();
+        const checked = document.querySelector('input[name="payment_method"]:checked');
+        if (checked) {
+            const defaultSection = document.querySelector(`[data-payment-info="${checked.value}"]`);
+            if (defaultSection) {
+                defaultSection.style.display = 'block';
+            }
+        }
     }
 
     function createHiddenInputs(orderInfo, selectedProducts, notes) {

--- a/project/orders/templates/orders/wompi_checkout.html
+++ b/project/orders/templates/orders/wompi_checkout.html
@@ -70,7 +70,7 @@
 
 {% block dashboard_js %}
 {{ block.super }}
-<script src="https://checkout.wompi.co/widget.js"></script>
+<script src="{{ widget_js_url }}"></script>
 <script>
     document.addEventListener('DOMContentLoaded', function() {
         const payButton = document.getElementById('wompi-pay-btn');
@@ -84,10 +84,13 @@
             reference: '{{ reference|escapejs }}',
             publicKey: '{{ public_key|escapejs }}',
             redirectUrl: '{{ redirect_url|escapejs }}',
-            acceptanceToken: {% if acceptance_data.presigned_acceptance.acceptance_token %}'{{ acceptance_data.presigned_acceptance.acceptance_token|escapejs }}'{% else %}null{% endif %},
+            acceptanceToken: {% if acceptance_token %}'{{ acceptance_token|escapejs }}'{% else %}null{% endif %},
             integritySignature: {% if integrity_signature %}'{{ integrity_signature|escapejs }}'{% else %}null{% endif %},
             signaturePayload: {% if integrity_signature_payload %}'{{ integrity_signature_payload|escapejs }}'{% else %}null{% endif %},
-            formattedAmount: '{{ amount_formatted|default:"0.00"|escapejs }}'
+            formattedAmount: '{{ amount_formatted|default:"0.00"|escapejs }}',
+            customerEmail: {% if customer_email %}'{{ customer_email|escapejs }}'{% else %}null{% endif %},
+            customerFullName: {% if customer_name %}'{{ customer_name|escapejs }}'{% else %}null{% endif %},
+            customerPhone: {% if customer_phone %}'{{ customer_phone|escapejs }}'{% else %}null{% endif %}
         };
 
         console.log('Wompi checkout data', wompiConfig);
@@ -96,6 +99,10 @@
             event.preventDefault();
 
             try {
+                if (typeof WidgetCheckout === 'undefined') {
+                    throw new Error('WidgetCheckout no está disponible. Verifica que el script de Wompi cargó correctamente.');
+                }
+
                 const checkoutOptions = {
                     currency: wompiConfig.currency,
                     amountInCents: wompiConfig.amountInCents,
@@ -112,6 +119,20 @@
 
                 if (wompiConfig.acceptanceToken) {
                     checkoutOptions.acceptanceToken = wompiConfig.acceptanceToken;
+                }
+
+                if (wompiConfig.customerEmail || wompiConfig.customerFullName || wompiConfig.customerPhone) {
+                    checkoutOptions.customerData = {};
+
+                    if (wompiConfig.customerEmail) {
+                        checkoutOptions.customerData.email = wompiConfig.customerEmail;
+                    }
+                    if (wompiConfig.customerFullName) {
+                        checkoutOptions.customerData.fullName = wompiConfig.customerFullName;
+                    }
+                    if (wompiConfig.customerPhone) {
+                        checkoutOptions.customerData.phoneNumber = wompiConfig.customerPhone;
+                    }
                 }
 
                 const checkout = new WidgetCheckout(checkoutOptions);

--- a/project/orders/templates/orders/wompi_checkout.html
+++ b/project/orders/templates/orders/wompi_checkout.html
@@ -78,27 +78,49 @@
             return;
         }
 
+        const wompiConfig = {
+            currency: 'COP',
+            amountInCents: {{ amount_in_cents|default:0 }},
+            reference: '{{ reference|escapejs }}',
+            publicKey: '{{ public_key|escapejs }}',
+            redirectUrl: '{{ redirect_url|escapejs }}',
+            integritySignature: {% if integrity_signature %}'{{ integrity_signature|escapejs }}'{% else %}null{% endif %},
+            signaturePayload: {% if integrity_signature_payload %}'{{ integrity_signature_payload|escapejs }}'{% else %}null{% endif %},
+            formattedAmount: '{{ amount_formatted|default:"0.00"|escapejs }}'
+        };
+
+        console.log('Wompi checkout data', wompiConfig);
+
         payButton.addEventListener('click', function(event) {
             event.preventDefault();
 
-            const checkout = new WidgetCheckout({
-                currency: 'COP',
-                amountInCents: {{ amount_in_cents|default:0 }},
-                reference: '{{ order.order_number|escapejs }}',
-                publicKey: '{{ public_key|escapejs }}',
-                redirectUrl: '{{ redirect_url|escapejs }}'{% if integrity_signature %},
-                signature: {
-                    integritySignature: '{{ integrity_signature }}'
-                }{% endif %}
-            });
+            try {
+                const checkoutOptions = {
+                    currency: wompiConfig.currency,
+                    amountInCents: wompiConfig.amountInCents,
+                    reference: wompiConfig.reference,
+                    publicKey: wompiConfig.publicKey,
+                    redirectUrl: wompiConfig.redirectUrl,
+                };
 
-            checkout.open(function(result) {
-                if (result && result.transaction && result.transaction.id) {
-                    const url = new URL('{{ redirect_url|escapejs }}');
-                    url.searchParams.set('transactionId', result.transaction.id);
-                    window.location.href = url.toString();
+                if (wompiConfig.integritySignature) {
+                    checkoutOptions.signature = {
+                        integritySignature: wompiConfig.integritySignature
+                    };
                 }
-            });
+
+                const checkout = new WidgetCheckout(checkoutOptions);
+
+                checkout.open(function(result) {
+                    if (result && result.transaction && result.transaction.id) {
+                        const url = new URL('{{ redirect_url|escapejs }}');
+                        url.searchParams.set('transactionId', result.transaction.id);
+                        window.location.href = url.toString();
+                    }
+                });
+            } catch (error) {
+                console.error('Error al abrir el widget de Wompi', error);
+            }
         });
     });
 </script>

--- a/project/orders/templates/orders/wompi_checkout.html
+++ b/project/orders/templates/orders/wompi_checkout.html
@@ -1,0 +1,105 @@
+{% extends "core/base_dashboard.html" %}
+{% load humanize %}
+
+{% block title %}Pagar con Wompi | Janay Pedidos{% endblock %}
+
+{% block main_content %}
+<div class="max-w-3xl mx-auto">
+    <div class="content-card">
+        <div class="content-header">
+            <h1 class="content-title">Completar pago con Wompi</h1>
+            <p class="content-description">Confirma el pago seguro de tu pedido sin salir de Janay.</p>
+        </div>
+
+        <div class="p-6 space-y-6">
+            <div class="bg-emerald-50 border border-emerald-200 rounded-xl p-4 flex items-start space-x-3">
+                <span class="material-icons text-emerald-600">lock</span>
+                <div>
+                    <p class="text-sm text-emerald-900">
+                        Te redirigiremos a la pasarela de Wompi para realizar el pago en línea. Al finalizar, volverás automáticamente a Janay.
+                    </p>
+                    {% if terms_link %}
+                        <p class="text-xs text-emerald-800 mt-2">
+                            Al continuar aceptas los <a href="{{ terms_link }}" class="text-emerald-700 underline" target="_blank" rel="noopener">términos y condiciones de Wompi</a>.
+                        </p>
+                    {% endif %}
+                </div>
+            </div>
+
+            <div class="border border-gray-200 rounded-xl p-4">
+                <h2 class="text-lg font-semibold text-gray-900 mb-4">Resumen del pedido</h2>
+                <dl class="space-y-2 text-sm text-gray-700">
+                    <div class="flex justify-between">
+                        <dt>Número de pedido:</dt>
+                        <dd class="font-medium">{{ order.order_number }}</dd>
+                    </div>
+                    <div class="flex justify-between">
+                        <dt>Cliente:</dt>
+                        <dd class="font-medium">{{ order.customer_name }}</dd>
+                    </div>
+                    <div class="flex justify-between">
+                        <dt>Total a pagar:</dt>
+                        <dd class="text-xl font-semibold text-orange-600">${{ order.total|intcomma }}</dd>
+                    </div>
+                </dl>
+            </div>
+
+            {% if acceptance_error %}
+                <div class="bg-red-50 border border-red-200 text-red-700 rounded-xl p-4">
+                    <p class="font-semibold">No pudimos iniciar el pago con Wompi.</p>
+                    <p class="text-sm mt-2">{{ acceptance_error }}</p>
+                    <p class="text-xs mt-2">Por favor intenta nuevamente en unos minutos o elige otro método de pago.</p>
+                </div>
+            {% endif %}
+        </div>
+
+        <div class="flex flex-col md:flex-row md:justify-between md:items-center border-t border-gray-200 p-4 md:p-6 space-y-3 md:space-y-0">
+            <a href="{% url 'orders:step3' %}" class="btn-step-cancel">
+                <span class="material-icons mr-2 text-sm">arrow_back</span>
+                Volver a mi pedido
+            </a>
+
+            <button id="wompi-pay-btn" class="btn-step-continue {% if acceptance_error %}opacity-50 cursor-not-allowed{% endif %}" {% if acceptance_error %}disabled{% endif %}>
+                Pagar con Wompi
+                <span class="material-icons ml-2 text-sm">payments</span>
+            </button>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block dashboard_js %}
+{{ block.super }}
+<script src="https://checkout.wompi.co/widget.js"></script>
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const payButton = document.getElementById('wompi-pay-btn');
+        if (!payButton || payButton.hasAttribute('disabled')) {
+            return;
+        }
+
+        payButton.addEventListener('click', function(event) {
+            event.preventDefault();
+
+            const checkout = new WidgetCheckout({
+                currency: 'COP',
+                amountInCents: {{ amount_in_cents|default:0 }},
+                reference: '{{ order.order_number|escapejs }}',
+                publicKey: '{{ public_key|escapejs }}',
+                redirectUrl: '{{ redirect_url|escapejs }}'{% if integrity_signature %},
+                signature: {
+                    integritySignature: '{{ integrity_signature }}'
+                }{% endif %}
+            });
+
+            checkout.open(function(result) {
+                if (result && result.transaction && result.transaction.id) {
+                    const url = new URL('{{ redirect_url|escapejs }}');
+                    url.searchParams.set('transactionId', result.transaction.id);
+                    window.location.href = url.toString();
+                }
+            });
+        });
+    });
+</script>
+{% endblock %}

--- a/project/orders/templates/orders/wompi_checkout.html
+++ b/project/orders/templates/orders/wompi_checkout.html
@@ -70,13 +70,53 @@
 
 {% block dashboard_js %}
 {{ block.super }}
-<script src="{{ widget_js_url }}"></script>
 <script>
     document.addEventListener('DOMContentLoaded', function() {
         const payButton = document.getElementById('wompi-pay-btn');
         if (!payButton || payButton.hasAttribute('disabled')) {
             return;
         }
+
+        const wompiScriptSources = JSON.parse('{{ widget_js_sources|escapejs }}');
+        let widgetReady = typeof WidgetCheckout !== 'undefined';
+        let loadedScriptUrl = widgetReady ? '{{ widget_js_url|escapejs }}' : null;
+
+        function markWidgetReady(scriptUrl) {
+            widgetReady = true;
+            loadedScriptUrl = scriptUrl;
+            console.info('Script de Wompi cargado correctamente:', scriptUrl);
+        }
+
+        function loadWompiScript(index) {
+            if (widgetReady) {
+                return;
+            }
+
+            if (!Array.isArray(wompiScriptSources) || wompiScriptSources.length === 0) {
+                console.error('No se configuraron URLs del widget de Wompi.');
+                return;
+            }
+
+            if (index >= wompiScriptSources.length) {
+                console.error('No fue posible cargar el script del widget de Wompi.');
+                return;
+            }
+
+            const scriptUrl = wompiScriptSources[index];
+            const scriptTag = document.createElement('script');
+            scriptTag.src = scriptUrl;
+            scriptTag.async = true;
+            scriptTag.onload = function() {
+                markWidgetReady(scriptUrl);
+            };
+            scriptTag.onerror = function() {
+                console.warn('Fallo al cargar el script de Wompi:', scriptUrl);
+                loadWompiScript(index + 1);
+            };
+            document.head.appendChild(scriptTag);
+        }
+
+        loadWompiScript(0);
 
         const wompiConfig = {
             currency: 'COP',
@@ -100,7 +140,9 @@
 
             try {
                 if (typeof WidgetCheckout === 'undefined') {
-                    throw new Error('WidgetCheckout no está disponible. Verifica que el script de Wompi cargó correctamente.');
+                    const message = 'WidgetCheckout no está disponible. Verifica que el script de Wompi cargó correctamente.';
+                    console.error(message, { loadedScriptUrl });
+                    throw new Error(message);
                 }
 
                 const checkoutOptions = {

--- a/project/orders/templates/orders/wompi_checkout.html
+++ b/project/orders/templates/orders/wompi_checkout.html
@@ -84,6 +84,7 @@
             reference: '{{ reference|escapejs }}',
             publicKey: '{{ public_key|escapejs }}',
             redirectUrl: '{{ redirect_url|escapejs }}',
+            acceptanceToken: {% if acceptance_data.presigned_acceptance.acceptance_token %}'{{ acceptance_data.presigned_acceptance.acceptance_token|escapejs }}'{% else %}null{% endif %},
             integritySignature: {% if integrity_signature %}'{{ integrity_signature|escapejs }}'{% else %}null{% endif %},
             signaturePayload: {% if integrity_signature_payload %}'{{ integrity_signature_payload|escapejs }}'{% else %}null{% endif %},
             formattedAmount: '{{ amount_formatted|default:"0.00"|escapejs }}'
@@ -105,8 +106,12 @@
 
                 if (wompiConfig.integritySignature) {
                     checkoutOptions.signature = {
-                        integritySignature: wompiConfig.integritySignature
+                        integrity: wompiConfig.integritySignature
                     };
+                }
+
+                if (wompiConfig.acceptanceToken) {
+                    checkoutOptions.acceptanceToken = wompiConfig.acceptanceToken;
                 }
 
                 const checkout = new WidgetCheckout(checkoutOptions);

--- a/project/orders/templates/orders/wompi_checkout.html
+++ b/project/orders/templates/orders/wompi_checkout.html
@@ -130,7 +130,9 @@
             formattedAmount: '{{ amount_formatted|default:"0.00"|escapejs }}',
             customerEmail: {% if customer_email %}'{{ customer_email|escapejs }}'{% else %}null{% endif %},
             customerFullName: {% if customer_name %}'{{ customer_name|escapejs }}'{% else %}null{% endif %},
-            customerPhone: {% if customer_phone %}'{{ customer_phone|escapejs }}'{% else %}null{% endif %}
+            customerPhone: {% if customer_phone %}'{{ customer_phone|escapejs }}'{% else %}null{% endif %},
+            customerPhonePrefix: {% if customer_phone_prefix %}'{{ customer_phone_prefix|escapejs }}'{% else %}null{% endif %},
+            customerPhoneRaw: {% if customer_phone_raw %}'{{ customer_phone_raw|escapejs }}'{% else %}null{% endif %}
         };
 
         console.log('Wompi checkout data', wompiConfig);
@@ -163,18 +165,27 @@
                     checkoutOptions.acceptanceToken = wompiConfig.acceptanceToken;
                 }
 
-                if (wompiConfig.customerEmail || wompiConfig.customerFullName || wompiConfig.customerPhone) {
-                    checkoutOptions.customerData = {};
+                const customerData = {};
 
-                    if (wompiConfig.customerEmail) {
-                        checkoutOptions.customerData.email = wompiConfig.customerEmail;
-                    }
-                    if (wompiConfig.customerFullName) {
-                        checkoutOptions.customerData.fullName = wompiConfig.customerFullName;
-                    }
-                    if (wompiConfig.customerPhone) {
-                        checkoutOptions.customerData.phoneNumber = wompiConfig.customerPhone;
-                    }
+                if (wompiConfig.customerEmail) {
+                    customerData.email = wompiConfig.customerEmail;
+                }
+                if (wompiConfig.customerFullName) {
+                    customerData.fullName = wompiConfig.customerFullName;
+                }
+                if (wompiConfig.customerPhone && wompiConfig.customerPhonePrefix) {
+                    customerData.phoneNumber = wompiConfig.customerPhone;
+                    customerData.phoneNumberPrefix = wompiConfig.customerPhonePrefix;
+                } else if (wompiConfig.customerPhoneRaw) {
+                    console.warn('No se pudo derivar un prefijo válido para el teléfono del cliente.', {
+                        raw: wompiConfig.customerPhoneRaw,
+                        normalized: wompiConfig.customerPhone,
+                        prefix: wompiConfig.customerPhonePrefix,
+                    });
+                }
+
+                if (Object.keys(customerData).length > 0) {
+                    checkoutOptions.customerData = customerData;
                 }
 
                 const checkout = new WidgetCheckout(checkoutOptions);

--- a/project/orders/templates/orders/wompi_result.html
+++ b/project/orders/templates/orders/wompi_result.html
@@ -1,0 +1,104 @@
+{% extends "core/base_dashboard.html" %}
+{% load humanize %}
+
+{% block title %}Resultado del pago | Janay Pedidos{% endblock %}
+
+{% block main_content %}
+<div class="max-w-3xl mx-auto">
+    <div class="content-card">
+        <div class="content-header">
+            <h1 class="content-title">Estado del pago</h1>
+            <p class="content-description">Revisamos la información recibida desde Wompi.</p>
+        </div>
+
+        <div class="p-6 space-y-6">
+            {% if error_message %}
+                <div class="bg-red-50 border border-red-200 text-red-700 rounded-xl p-4">
+                    <p class="font-semibold">No pudimos confirmar el pago.</p>
+                    <p class="text-sm mt-2">{{ error_message }}</p>
+                    <p class="text-xs mt-2">Puedes intentar nuevamente desde la opción de pago o comunicarte con nosotros.</p>
+                </div>
+            {% else %}
+                <div class="rounded-xl p-4 border flex items-start space-x-3 {% if transaction_status == 'APPROVED' %}bg-emerald-50 border-emerald-200 text-emerald-900{% elif transaction_status == 'PENDING' %}bg-yellow-50 border-yellow-200 text-yellow-900{% else %}bg-gray-50 border-gray-200 text-gray-900{% endif %}">
+                    <span class="material-icons">
+                        {% if transaction_status == 'APPROVED' %}check_circle{% elif transaction_status == 'PENDING' %}hourglass_bottom{% else %}info{% endif %}
+                    </span>
+                    <div>
+                        <p class="text-base font-semibold">{{ transaction_status_label }}</p>
+                        {% if transaction_status == 'APPROVED' %}
+                            <p class="text-sm mt-1">Tu pago fue aprobado exitosamente. ¡Gracias por confiar en Janay!</p>
+                        {% elif transaction_status == 'PENDING' %}
+                            <p class="text-sm mt-1">El pago está en proceso de validación. Te notificaremos en cuanto recibamos la confirmación.</p>
+                        {% else %}
+                            <p class="text-sm mt-1">Recibimos una respuesta de Wompi con estado "{{ transaction_status_label }}".</p>
+                        {% endif %}
+                    </div>
+                </div>
+            {% endif %}
+
+            <div class="border border-gray-200 rounded-xl p-4">
+                <h2 class="text-lg font-semibold text-gray-900 mb-4">Resumen del pedido</h2>
+                <dl class="space-y-2 text-sm text-gray-700">
+                    <div class="flex justify-between">
+                        <dt>Pedido:</dt>
+                        <dd class="font-medium">{{ order.order_number }}</dd>
+                    </div>
+                    <div class="flex justify-between">
+                        <dt>Total:</dt>
+                        <dd class="font-semibold text-orange-600">${{ order.total|intcomma }}</dd>
+                    </div>
+                    <div class="flex justify-between">
+                        <dt>Estado del pago:</dt>
+                        <dd class="font-medium">{{ order.get_payment_status_display }}</dd>
+                    </div>
+                    {% if transaction_id %}
+                    <div class="flex justify-between">
+                        <dt>ID de transacción:</dt>
+                        <dd class="font-mono text-xs">{{ transaction_id }}</dd>
+                    </div>
+                    {% endif %}
+                </dl>
+            </div>
+
+            {% if transaction %}
+                <div class="border border-gray-200 rounded-xl p-4">
+                    <h2 class="text-lg font-semibold text-gray-900 mb-4">Información de la transacción</h2>
+                    <dl class="space-y-2 text-sm text-gray-700">
+                        {% if transaction.reference %}
+                        <div class="flex justify-between">
+                            <dt>Referencia:</dt>
+                            <dd class="font-medium">{{ transaction.reference }}</dd>
+                        </div>
+                        {% endif %}
+                        {% if transaction_amount %}
+                        <div class="flex justify-between">
+                            <dt>Monto reportado:</dt>
+                            <dd class="font-medium">${{ transaction_amount|intcomma }}</dd>
+                        </div>
+                        {% endif %}
+                        {% if transaction.payment_method_type %}
+                        <div class="flex justify-between">
+                            <dt>Método:</dt>
+                            <dd class="font-medium">{{ transaction.payment_method_type|title }}</dd>
+                        </div>
+                        {% endif %}
+                        {% if transaction.status_message %}
+                        <div class="flex justify-between">
+                            <dt>Mensaje:</dt>
+                            <dd class="font-medium text-sm text-gray-600">{{ transaction.status_message }}</dd>
+                        </div>
+                        {% endif %}
+                    </dl>
+                </div>
+            {% endif %}
+        </div>
+
+        <div class="flex justify-end border-t border-gray-200 p-4 md:p-6">
+            <a href="{% url 'orders:success' order.id %}" class="btn-step-continue">
+                Ver pedido confirmado
+                <span class="material-icons ml-2 text-sm">arrow_forward</span>
+            </a>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/project/orders/urls.py
+++ b/project/orders/urls.py
@@ -9,10 +9,12 @@ urlpatterns = [
     path('create/step1/', views.order_step1, name='step1'),
     path('create/step2/', views.order_step2, name='step2'),
     path('create/step3/', views.order_step3, name='step3'),
-    
+
     # Éxito de pedido
     path('success/<int:order_id>/', views.order_success, name='success'),
-    
+    path('payment/wompi/<int:order_id>/', views.wompi_checkout, name='wompi_checkout'),
+    path('payment/wompi/<int:order_id>/resultado/', views.wompi_result, name='wompi_result'),
+
     # Gestión del carrito
     path('cart/add/<int:product_id>/', views.add_to_cart, name='add_to_cart'),
     path('cart/remove/<int:product_id>/', views.remove_from_cart, name='remove_from_cart'),

--- a/project/orders/views.py
+++ b/project/orders/views.py
@@ -19,6 +19,7 @@ from .services import (
     get_acceptance_information,
     get_transaction_information,
     get_wompi_base_url,
+    split_phone_number,
 )
 from products.models import Product, Category
 
@@ -529,6 +530,9 @@ def wompi_checkout(request, order_id):
         signature_payload = f"{reference}{amount_in_cents}COP{integrity_key}"
         integrity_signature = hashlib.sha256(signature_payload.encode('utf-8')).hexdigest()
 
+    customer_phone_raw = (order.customer_phone or '').strip()
+    phone_prefix, phone_number = split_phone_number(customer_phone_raw)
+
     context = {
         'order': order,
         'settings': settings_obj,
@@ -547,7 +551,9 @@ def wompi_checkout(request, order_id):
         'integrity_signature': integrity_signature,
         'integrity_signature_payload': signature_payload,
         'customer_email': (order.customer_email or '').strip(),
-        'customer_phone': (order.customer_phone or '').strip(),
+        'customer_phone': phone_number,
+        'customer_phone_prefix': phone_prefix,
+        'customer_phone_raw': customer_phone_raw,
         'customer_name': (order.customer_name or '').strip(),
     }
 

--- a/project/orders/views.py
+++ b/project/orders/views.py
@@ -534,6 +534,7 @@ def wompi_checkout(request, order_id):
         'settings': settings_obj,
         'environment': env,
         'widget_js_url': env.widget_js_url,
+        'widget_js_sources': json.dumps(env.widget_js_urls),
         'amount_in_cents': amount_in_cents,
         'amount_formatted': f"{total_amount:.2f}",
         'reference': reference,

--- a/project/theme/static/css/dist/styles.css
+++ b/project/theme/static/css/dist/styles.css
@@ -4302,6 +4302,10 @@ select {
   min-width: 100%;
 }
 
+.max-w-3xl {
+  max-width: 48rem;
+}
+
 .max-w-7xl {
   max-width: 80rem;
 }
@@ -4381,6 +4385,10 @@ select {
   align-items: center;
 }
 
+.justify-end {
+  justify-content: flex-end;
+}
+
 .justify-center {
   justify-content: center;
 }
@@ -4416,6 +4424,12 @@ select {
 
 .gap-y-6 {
   row-gap: 1.5rem;
+}
+
+.space-x-3 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(0.75rem * var(--tw-space-x-reverse));
+  margin-left: calc(0.75rem * calc(1 - var(--tw-space-x-reverse)));
 }
 
 .space-x-4 > :not([hidden]) ~ :not([hidden]) {
@@ -4503,6 +4517,10 @@ select {
   border-radius: 0.375rem;
 }
 
+.rounded-xl {
+  border-radius: 0.75rem;
+}
+
 .border {
   border-width: 1px;
 }
@@ -4531,6 +4549,11 @@ select {
 .border-blue-200 {
   --tw-border-opacity: 1;
   border-color: rgb(191 219 254 / var(--tw-border-opacity, 1));
+}
+
+.border-emerald-200 {
+  --tw-border-opacity: 1;
+  border-color: rgb(167 243 208 / var(--tw-border-opacity, 1));
 }
 
 .border-gray-100 {
@@ -4583,6 +4606,11 @@ select {
   border-color: rgb(194 65 12 / var(--tw-border-opacity, 1));
 }
 
+.border-red-200 {
+  --tw-border-opacity: 1;
+  border-color: rgb(254 202 202 / var(--tw-border-opacity, 1));
+}
+
 .border-red-400 {
   --tw-border-opacity: 1;
   border-color: rgb(248 113 113 / var(--tw-border-opacity, 1));
@@ -4595,6 +4623,11 @@ select {
 
 .border-transparent {
   border-color: transparent;
+}
+
+.border-yellow-200 {
+  --tw-border-opacity: 1;
+  border-color: rgb(254 240 138 / var(--tw-border-opacity, 1));
 }
 
 .border-yellow-400 {
@@ -4615,6 +4648,11 @@ select {
 .bg-blue-50 {
   --tw-bg-opacity: 1;
   background-color: rgb(239 246 255 / var(--tw-bg-opacity, 1));
+}
+
+.bg-emerald-50 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(236 253 245 / var(--tw-bg-opacity, 1));
 }
 
 .bg-gray-100 {
@@ -4706,6 +4744,11 @@ select {
   background-color: rgb(254 226 226 / var(--tw-bg-opacity, 1));
 }
 
+.bg-red-50 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 242 242 / var(--tw-bg-opacity, 1));
+}
+
 .bg-red-600 {
   --tw-bg-opacity: 1;
   background-color: rgb(220 38 38 / var(--tw-bg-opacity, 1));
@@ -4723,6 +4766,11 @@ select {
 .bg-yellow-100 {
   --tw-bg-opacity: 1;
   background-color: rgb(254 249 195 / var(--tw-bg-opacity, 1));
+}
+
+.bg-yellow-50 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 252 232 / var(--tw-bg-opacity, 1));
 }
 
 .bg-opacity-50 {
@@ -4848,6 +4896,10 @@ select {
   vertical-align: middle;
 }
 
+.font-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
 .font-serif {
   font-family: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
 }
@@ -4970,6 +5022,26 @@ select {
 .text-blue-900 {
   --tw-text-opacity: 1;
   color: rgb(30 58 138 / var(--tw-text-opacity, 1));
+}
+
+.text-emerald-600 {
+  --tw-text-opacity: 1;
+  color: rgb(5 150 105 / var(--tw-text-opacity, 1));
+}
+
+.text-emerald-700 {
+  --tw-text-opacity: 1;
+  color: rgb(4 120 87 / var(--tw-text-opacity, 1));
+}
+
+.text-emerald-800 {
+  --tw-text-opacity: 1;
+  color: rgb(6 95 70 / var(--tw-text-opacity, 1));
+}
+
+.text-emerald-900 {
+  --tw-text-opacity: 1;
+  color: rgb(6 78 59 / var(--tw-text-opacity, 1));
 }
 
 .text-gray-300 {
@@ -5115,6 +5187,15 @@ select {
 .text-yellow-800 {
   --tw-text-opacity: 1;
   color: rgb(133 77 14 / var(--tw-text-opacity, 1));
+}
+
+.text-yellow-900 {
+  --tw-text-opacity: 1;
+  color: rgb(113 63 18 / var(--tw-text-opacity, 1));
+}
+
+.underline {
+  text-decoration-line: underline;
 }
 
 .line-through {
@@ -5385,6 +5466,11 @@ input[type="password"]::-ms-clear {
   border-color: rgb(59 130 246 / var(--tw-border-opacity, 1));
 }
 
+.peer:checked ~ .peer-checked\:border-emerald-500 {
+  --tw-border-opacity: 1;
+  border-color: rgb(16 185 129 / var(--tw-border-opacity, 1));
+}
+
 .peer:checked ~ .peer-checked\:border-green-500 {
   --tw-border-opacity: 1;
   border-color: rgb(34 197 94 / var(--tw-border-opacity, 1));
@@ -5395,14 +5481,14 @@ input[type="password"]::-ms-clear {
   border-color: rgb(249 115 22 / var(--tw-border-opacity, 1));
 }
 
-.peer:checked ~ .peer-checked\:border-purple-500 {
-  --tw-border-opacity: 1;
-  border-color: rgb(168 85 247 / var(--tw-border-opacity, 1));
-}
-
 .peer:checked ~ .peer-checked\:bg-blue-50 {
   --tw-bg-opacity: 1;
   background-color: rgb(239 246 255 / var(--tw-bg-opacity, 1));
+}
+
+.peer:checked ~ .peer-checked\:bg-emerald-50 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(236 253 245 / var(--tw-bg-opacity, 1));
 }
 
 .peer:checked ~ .peer-checked\:bg-green-50 {
@@ -5413,11 +5499,6 @@ input[type="password"]::-ms-clear {
 .peer:checked ~ .peer-checked\:bg-orange-50 {
   --tw-bg-opacity: 1;
   background-color: rgb(255 247 237 / var(--tw-bg-opacity, 1));
-}
-
-.peer:checked ~ .peer-checked\:bg-purple-50 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(250 245 255 / var(--tw-bg-opacity, 1));
 }
 
 @media (min-width: 640px) {

--- a/project/theme/static/css/dist/styles.css
+++ b/project/theme/static/css/dist/styles.css
@@ -4330,10 +4330,6 @@ select {
   flex-grow: 1;
 }
 
-.border-collapse {
-  border-collapse: collapse;
-}
-
 .-translate-x-1\/2 {
   --tw-translate-x: -50%;
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
@@ -4545,11 +4541,6 @@ select {
   border-top-width: 2px;
 }
 
-.border-amber-200 {
-  --tw-border-opacity: 1;
-  border-color: rgb(253 230 138 / var(--tw-border-opacity, 1));
-}
-
 .border-black {
   --tw-border-opacity: 1;
   border-color: rgb(0 0 0 / var(--tw-border-opacity, 1));
@@ -4642,11 +4633,6 @@ select {
 .border-yellow-400 {
   --tw-border-opacity: 1;
   border-color: rgb(250 204 21 / var(--tw-border-opacity, 1));
-}
-
-.bg-amber-50 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(255 251 235 / var(--tw-bg-opacity, 1));
 }
 
 .bg-black {
@@ -5006,11 +4992,6 @@ select {
 
 .tracking-wider {
   letter-spacing: 0.05em;
-}
-
-.text-amber-700 {
-  --tw-text-opacity: 1;
-  color: rgb(180 83 9 / var(--tw-text-opacity, 1));
 }
 
 .text-blue-400 {
@@ -5641,10 +5622,6 @@ input[type="password"]::-ms-clear {
     width: 16rem;
   }
 
-  .md\:w-auto {
-    width: auto;
-  }
-
   .md\:grid-cols-2 {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -5671,12 +5648,6 @@ input[type="password"]::-ms-clear {
 
   .md\:gap-6 {
     gap: 1.5rem;
-  }
-
-  .md\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
-    --tw-space-x-reverse: 0;
-    margin-right: calc(1rem * var(--tw-space-x-reverse));
-    margin-left: calc(1rem * calc(1 - var(--tw-space-x-reverse)));
   }
 
   .md\:space-y-0 > :not([hidden]) ~ :not([hidden]) {

--- a/project/theme/static/css/dist/styles.css
+++ b/project/theme/static/css/dist/styles.css
@@ -5481,6 +5481,11 @@ input[type="password"]::-ms-clear {
   border-color: rgb(249 115 22 / var(--tw-border-opacity, 1));
 }
 
+.peer:checked ~ .peer-checked\:border-purple-500 {
+  --tw-border-opacity: 1;
+  border-color: rgb(168 85 247 / var(--tw-border-opacity, 1));
+}
+
 .peer:checked ~ .peer-checked\:bg-blue-50 {
   --tw-bg-opacity: 1;
   background-color: rgb(239 246 255 / var(--tw-bg-opacity, 1));
@@ -5499,6 +5504,11 @@ input[type="password"]::-ms-clear {
 .peer:checked ~ .peer-checked\:bg-orange-50 {
   --tw-bg-opacity: 1;
   background-color: rgb(255 247 237 / var(--tw-bg-opacity, 1));
+}
+
+.peer:checked ~ .peer-checked\:bg-purple-50 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(250 245 255 / var(--tw-bg-opacity, 1));
 }
 
 @media (min-width: 640px) {

--- a/project/theme/static/css/dist/styles.css
+++ b/project/theme/static/css/dist/styles.css
@@ -4330,6 +4330,10 @@ select {
   flex-grow: 1;
 }
 
+.border-collapse {
+  border-collapse: collapse;
+}
+
 .-translate-x-1\/2 {
   --tw-translate-x: -50%;
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
@@ -4541,6 +4545,11 @@ select {
   border-top-width: 2px;
 }
 
+.border-amber-200 {
+  --tw-border-opacity: 1;
+  border-color: rgb(253 230 138 / var(--tw-border-opacity, 1));
+}
+
 .border-black {
   --tw-border-opacity: 1;
   border-color: rgb(0 0 0 / var(--tw-border-opacity, 1));
@@ -4633,6 +4642,11 @@ select {
 .border-yellow-400 {
   --tw-border-opacity: 1;
   border-color: rgb(250 204 21 / var(--tw-border-opacity, 1));
+}
+
+.bg-amber-50 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 251 235 / var(--tw-bg-opacity, 1));
 }
 
 .bg-black {
@@ -4992,6 +5006,11 @@ select {
 
 .tracking-wider {
   letter-spacing: 0.05em;
+}
+
+.text-amber-700 {
+  --tw-text-opacity: 1;
+  color: rgb(180 83 9 / var(--tw-text-opacity, 1));
 }
 
 .text-blue-400 {
@@ -5622,6 +5641,10 @@ input[type="password"]::-ms-clear {
     width: 16rem;
   }
 
+  .md\:w-auto {
+    width: auto;
+  }
+
   .md\:grid-cols-2 {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -5648,6 +5671,12 @@ input[type="password"]::-ms-clear {
 
   .md\:gap-6 {
     gap: 1.5rem;
+  }
+
+  .md\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(1rem * var(--tw-space-x-reverse));
+    margin-left: calc(1rem * calc(1 - var(--tw-space-x-reverse)));
   }
 
   .md\:space-y-0 > :not([hidden]) ~ :not([hidden]) {


### PR DESCRIPTION
## Summary
- simplify the BusinessSettings payment toggles to cash and Wompi, storing the integrity key alongside new defaults via a migration
- render Step 3 payment options dynamically from the order model and reuse any pending Wompi order while keeping the cart in session
- update the Wompi checkout flow to sign widget launches, allow returning to Step 3, and clear session data once a transaction is approved

## Testing
- `python -m compileall project/orders`


------
https://chatgpt.com/codex/tasks/task_e_68d879165a388330b6bd18f2504e8b0f