### PR TITLE
Validate Wompi credentials and accept signed webhooks

### DIFF
--- a/project/orders/admin.py
+++ b/project/orders/admin.py
@@ -24,7 +24,7 @@ class OrderAdmin(ModelAdmin):
         'created_at', 'delivery_city'
     )
     search_fields = ('order_number', 'customer_name', 'customer_phone', 'customer_email')
-    readonly_fields = ('order_number', 'subtotal', 'total', 'created_at', 'updated_at')
+    readonly_fields = ('order_number', 'subtotal', 'total', 'created_at', 'updated_at', 'payment_reference')
     inlines = [OrderItemInline]
     date_hierarchy = 'desired_date'
     
@@ -46,7 +46,7 @@ class OrderAdmin(ModelAdmin):
             'fields': ('desired_date', 'desired_time', 'estimated_delivery', 'created_at', 'updated_at')
         }),
         ('Pagos', {
-            'fields': ('payment_status', 'payment_method')
+            'fields': ('payment_status', 'payment_method', 'payment_reference')
         }),
         ('Totales', {
             'fields': ('subtotal', 'delivery_fee', 'total')
@@ -317,7 +317,17 @@ class BusinessSettingsAdmin(ModelAdmin):
             'fields': ('delivery_start_time', 'delivery_end_time')
         }),
         ('Métodos de Pago', {
-            'fields': ('accept_cash', 'accept_transfer', 'accept_card', 'accept_pse')
+            'fields': ('accept_cash', 'accept_wompi')
+        }),
+        ('Configuración Wompi', {
+            'fields': (
+                'wompi_environment',
+                'wompi_public_key',
+                'wompi_private_key',
+                'wompi_integrity_key',
+                'wompi_event_key',
+            ),
+            'description': 'Configura las llaves proporcionadas por Wompi para habilitar pagos en línea.'
         }),
     )
     

--- a/project/orders/migrations/0008_wompi_integration.py
+++ b/project/orders/migrations/0008_wompi_integration.py
@@ -1,0 +1,59 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('orders', '0007_remove_ordermodificationrequest_status_and_more'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='order',
+            name='payment_reference',
+            field=models.CharField(
+                blank=True,
+                help_text='Identificador de la transacción en la pasarela de pago',
+                max_length=120,
+                verbose_name='Referencia de pago',
+            ),
+        ),
+        migrations.AddField(
+            model_name='businesssettings',
+            name='accept_wompi',
+            field=models.BooleanField(
+                default=False,
+                verbose_name='Aceptar pagos con Wompi',
+            ),
+        ),
+        migrations.AddField(
+            model_name='businesssettings',
+            name='wompi_environment',
+            field=models.CharField(
+                choices=[('test', 'Sandbox/Pruebas'), ('production', 'Producción')],
+                default='test',
+                max_length=20,
+                verbose_name='Entorno de Wompi',
+            ),
+        ),
+        migrations.AddField(
+            model_name='businesssettings',
+            name='wompi_private_key',
+            field=models.CharField(
+                blank=True,
+                help_text='Llave privada provista por Wompi para consultar transacciones',
+                max_length=120,
+                verbose_name='Llave privada Wompi',
+            ),
+        ),
+        migrations.AddField(
+            model_name='businesssettings',
+            name='wompi_public_key',
+            field=models.CharField(
+                blank=True,
+                help_text='Llave pública provista por Wompi (pub_test_xxx o pub_prod_xxx)',
+                max_length=120,
+                verbose_name='Llave pública Wompi',
+            ),
+        ),
+    ]

--- a/project/orders/migrations/0009_update_payment_methods.py
+++ b/project/orders/migrations/0009_update_payment_methods.py
@@ -1,0 +1,41 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('orders', '0008_wompi_integration'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='businesssettings',
+            name='accept_card',
+        ),
+        migrations.RemoveField(
+            model_name='businesssettings',
+            name='accept_pse',
+        ),
+        migrations.RemoveField(
+            model_name='businesssettings',
+            name='accept_transfer',
+        ),
+        migrations.AlterField(
+            model_name='businesssettings',
+            name='accept_wompi',
+            field=models.BooleanField(
+                default=True,
+                verbose_name='Aceptar pagos con Wompi',
+            ),
+        ),
+        migrations.AddField(
+            model_name='businesssettings',
+            name='wompi_integrity_key',
+            field=models.CharField(
+                blank=True,
+                help_text='Llave usada para firmar los pagos iniciados desde el widget de Wompi',
+                max_length=120,
+                verbose_name='Llave de integridad Wompi',
+            ),
+        ),
+    ]

--- a/project/orders/migrations/0010_businesssettings_wompi_event_key.py
+++ b/project/orders/migrations/0010_businesssettings_wompi_event_key.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('orders', '0009_update_payment_methods'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='businesssettings',
+            name='wompi_event_key',
+            field=models.CharField(
+                blank=True,
+                help_text='Llave usada para verificar la firma de los eventos enviados por Wompi',
+                max_length=120,
+                verbose_name='Llave de eventos Wompi',
+            ),
+        ),
+    ]

--- a/project/orders/models.py
+++ b/project/orders/models.py
@@ -40,6 +40,7 @@ class Order(models.Model):
         ('transfer', 'Transferencia'),
         ('card', 'Tarjeta'),
         ('pse', 'PSE'),
+        ('wompi', 'Wompi'),
         ('pay_later', 'Pagar después'),
     ]
     
@@ -77,6 +78,12 @@ class Order(models.Model):
     # Información de pago
     payment_status = models.CharField(max_length=20, choices=PAYMENT_STATUS, default='pending', verbose_name='Estado del pago')
     payment_method = models.CharField(max_length=20, choices=PAYMENT_METHOD, blank=True, verbose_name='Método de pago')
+    payment_reference = models.CharField(
+        max_length=120,
+        blank=True,
+        verbose_name='Referencia de pago',
+        help_text='Identificador de la transacción en la pasarela de pago'
+    )
     
     # Notas y comentarios
     notes = models.TextField(blank=True, verbose_name='Notas del cliente')
@@ -340,9 +347,38 @@ class BusinessSettings(models.Model):
     
     # Configuraciones de pago
     accept_cash = models.BooleanField(default=True, verbose_name='Acepta efectivo')
-    accept_transfer = models.BooleanField(default=True, verbose_name='Acepta transferencia')
-    accept_card = models.BooleanField(default=True, verbose_name='Acepta tarjeta')
-    accept_pse = models.BooleanField(default=False, verbose_name='Acepta PSE')
+    accept_wompi = models.BooleanField(default=True, verbose_name='Aceptar pagos con Wompi')
+
+    wompi_public_key = models.CharField(
+        max_length=120,
+        blank=True,
+        verbose_name='Llave pública Wompi',
+        help_text='Llave pública provista por Wompi (pub_test_xxx o pub_prod_xxx)'
+    )
+    wompi_private_key = models.CharField(
+        max_length=120,
+        blank=True,
+        verbose_name='Llave privada Wompi',
+        help_text='Llave privada provista por Wompi para consultar transacciones'
+    )
+    wompi_integrity_key = models.CharField(
+        max_length=120,
+        blank=True,
+        verbose_name='Llave de integridad Wompi',
+        help_text='Llave usada para firmar los pagos iniciados desde el widget de Wompi'
+    )
+    wompi_event_key = models.CharField(
+        max_length=120,
+        blank=True,
+        verbose_name='Llave de eventos Wompi',
+        help_text='Llave usada para verificar la firma de los eventos enviados por Wompi'
+    )
+    wompi_environment = models.CharField(
+        max_length=20,
+        choices=[('test', 'Sandbox/Pruebas'), ('production', 'Producción')],
+        default='test',
+        verbose_name='Entorno de Wompi'
+    )
     
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
@@ -369,6 +405,7 @@ class BusinessSettings(models.Model):
                 department='Casanare',
                 delivery_cost=Decimal('5000'),
                 modification_time_limit_hours=4,  # ✅ AGREGAR valores por defecto
-                cancellation_time_limit_days=1
+                cancellation_time_limit_days=1,
+                accept_wompi=True,
             )
         return settings

--- a/project/orders/services/__init__.py
+++ b/project/orders/services/__init__.py
@@ -1,0 +1,15 @@
+"""Servicios y utilidades para integraciones externas del módulo de pedidos."""
+
+from .wompi import (
+    WompiAPIError,
+    get_acceptance_information,
+    get_transaction_information,
+    get_wompi_base_url,
+)
+
+__all__ = [
+    'WompiAPIError',
+    'get_acceptance_information',
+    'get_transaction_information',
+    'get_wompi_base_url',
+]

--- a/project/orders/services/wompi.py
+++ b/project/orders/services/wompi.py
@@ -1,0 +1,208 @@
+"""Funciones auxiliares para la integración con la pasarela Wompi."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Optional, Tuple
+from urllib import error, request
+
+
+class WompiAPIError(Exception):
+    """Error genérico al comunicarse con los servicios de Wompi."""
+
+
+@dataclass
+class WompiEnvironment:
+    """Representa la configuración base según el entorno."""
+
+    api_url: str
+    widget_js_url: str
+    widget_js_urls: Tuple[str, ...]
+
+
+def get_wompi_base_url(environment: str) -> WompiEnvironment:
+    """Obtiene las URLs base para el entorno configurado."""
+
+    environment = (environment or 'test').lower()
+    if environment == 'production':
+        return WompiEnvironment(
+            api_url='https://production.wompi.co',
+            widget_js_url='https://checkout.wompi.co/widget.js',
+            widget_js_urls=(
+                'https://checkout.wompi.co/widget.js',
+                'https://cdn.wompi.co/widget.js',
+            ),
+        )
+    return WompiEnvironment(
+        api_url='https://sandbox.wompi.co',
+        widget_js_url='https://checkout.wompi.co/widget.js',
+        widget_js_urls=(
+            'https://checkout.wompi.co/widget.js',
+            'https://cdn.wompi.co/widget.js',
+        ),
+    )
+
+
+def _perform_get(url: str, *, headers: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
+    """Realiza un GET simple y devuelve el JSON de respuesta."""
+
+    req = request.Request(url, headers=headers or {})
+    try:
+        with request.urlopen(req, timeout=15) as response:
+            payload = response.read().decode('utf-8')
+    except error.HTTPError as exc:  # pragma: no cover - controlamos el mensaje
+        raise WompiAPIError(
+            f"Wompi respondió con un error HTTP {exc.code}: {exc.reason}"
+        ) from exc
+    except error.URLError as exc:  # pragma: no cover - dependerá de la red
+        raise WompiAPIError('No fue posible conectarse con Wompi. Intenta nuevamente.') from exc
+
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError as exc:  # pragma: no cover - respuesta inesperada
+        raise WompiAPIError('La respuesta de Wompi no es válida.') from exc
+
+
+def get_acceptance_information(public_key: str, environment: str) -> Dict[str, Any]:
+    """Obtiene información de aceptación (términos y token) para el comercio."""
+
+    public_key = (public_key or '').strip()
+    if not public_key:
+        raise WompiAPIError('No se configuró la llave pública de Wompi.')
+
+    env = get_wompi_base_url(environment)
+    data = _perform_get(f"{env.api_url}/v1/merchants/{public_key}")
+    return data.get('data', {})
+
+
+def get_transaction_information(
+    transaction_id: str,
+    environment: str,
+    *,
+    public_key: Optional[str] = None,
+    private_key: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Consulta el estado de una transacción específica."""
+
+    transaction_id = (transaction_id or '').strip()
+    if not transaction_id:
+        raise WompiAPIError('No se proporcionó el identificador de la transacción.')
+
+    env = get_wompi_base_url(environment)
+    headers: Dict[str, str] = {}
+    token = (private_key or public_key or '').strip()
+    if token:
+        headers['Authorization'] = f'Bearer {token}'
+
+    data = _perform_get(f"{env.api_url}/v1/transactions/{transaction_id}", headers=headers)
+    return data.get('data', {})
+
+
+__all__ = [
+    'WompiAPIError',
+    'get_acceptance_information',
+    'get_transaction_information',
+    'get_wompi_base_url',
+]
+
+
+def split_phone_number(
+    phone_number: str,
+    *,
+    default_prefix: str = '57',
+) -> Tuple[Optional[str], Optional[str]]:
+    """Divide un teléfono en prefijo y número para el widget de Wompi."""
+
+    digits = re.sub(r'\D+', '', phone_number or '')
+    if not digits:
+        return None, None
+
+    # Eliminar prefijos internacionales comunes "00"
+    if digits.startswith('00'):
+        digits = digits[2:]
+
+    if not digits:
+        return None, None
+
+    # La integración en Colombia usa "57" como prefijo internacional
+    default_prefix = re.sub(r'\D+', '', default_prefix or '') or '57'
+
+    prefix: Optional[str] = None
+    local_number: Optional[str] = None
+
+    if digits.startswith('57') and len(digits) > 2:
+        prefix = '57'
+        local_number = digits[2:]
+    elif digits.startswith(default_prefix) and len(digits) > len(default_prefix):
+        prefix = default_prefix
+        local_number = digits[len(default_prefix):]
+    else:
+        prefix = default_prefix
+        local_number = digits[-10:] if len(digits) > 10 else digits
+
+    if not local_number:
+        return None, None
+
+    # Asegurar que no existan ceros a la izquierda innecesarios
+    local_number = local_number.lstrip('0') or local_number
+
+    if len(local_number) < 6:  # Wompi requiere al menos 6 dígitos significativos
+        return None, None
+
+    return prefix, local_number
+
+
+__all__.append('split_phone_number')
+
+
+def normalize_wompi_key(key: Optional[str]) -> str:
+    """Elimina espacios en blanco comunes de una llave de Wompi."""
+
+    return (key or '').strip()
+
+
+def detect_wompi_key_environment(key: Optional[str]) -> Optional[str]:
+    """Intenta inferir si una llave es de pruebas o producción."""
+
+    normalized = normalize_wompi_key(key)
+    if not normalized:
+        return None
+
+    prefixes: Dict[str, Iterable[str]] = {
+        'test': ('pub_test', 'prv_test', 'evn_test', 'integrity_test'),
+        'production': ('pub_prod', 'prv_prod', 'evn_prod', 'integrity_prod'),
+    }
+    for env, env_prefixes in prefixes.items():
+        if any(normalized.startswith(prefix) for prefix in env_prefixes):
+            return env
+    return None
+
+
+def verify_event_signature(event_key: str, payload: bytes, provided_signature: str) -> bool:
+    """Valida la firma de un evento recibido desde Wompi."""
+
+    event_key = normalize_wompi_key(event_key)
+    provided_signature = (provided_signature or '').strip()
+    if not event_key or not payload or not provided_signature:
+        return False
+
+    if provided_signature.startswith('sha256='):
+        provided_signature = provided_signature.split('=', 1)[1]
+
+    digest = hmac.new(
+        event_key.encode('utf-8'),
+        payload,
+        hashlib.sha256,
+    ).hexdigest()
+    return hmac.compare_digest(digest, provided_signature)
+
+
+__all__.extend([
+    'normalize_wompi_key',
+    'detect_wompi_key_environment',
+    'verify_event_signature',
+])

--- a/project/orders/templates/orders/step3.html
+++ b/project/orders/templates/orders/step3.html
@@ -111,68 +111,34 @@
                 </h3>
                 
                 <div class="mt-4 space-y-3">
-                    <!-- Efectivo -->
+                    {% for method in payment_methods %}
                     <label class="radio-option">
-                        <input type="radio" name="payment_method" value="cash" 
-                               class="radio-option-input peer" checked>
-                        <div class="payment-option-card peer-checked:border-green-500 peer-checked:bg-green-50">
+                        <input type="radio" name="payment_method" value="{{ method.value }}"
+                               class="radio-option-input peer"
+                               {% if method.value == default_payment_method %}checked{% elif not default_payment_method and forloop.first %}checked{% endif %}>
+                        <div class="payment-option-card {{ method.card_classes }}">
                             <div class="payment-option-content">
                                 <div class="payment-option-icon">
-                                    <span class="material-icons text-green-600">payments</span>
+                                    <span class="material-icons {{ method.icon_classes }}">{{ method.icon }}</span>
                                 </div>
                                 <div class="payment-option-text">
-                                    <div class="payment-option-title">Efectivo</div>
-                                    <div class="payment-option-description">Pago al recibir</div>
+                                    <div class="payment-option-title">{{ method.label }}</div>
+                                    <div class="payment-option-description">{{ method.description }}</div>
                                 </div>
                             </div>
                         </div>
                     </label>
-
-                    <!-- Transferencia -->
-                    <label class="radio-option">
-                        <input type="radio" name="payment_method" value="transfer" 
-                               class="radio-option-input peer">
-                        <div class="payment-option-card peer-checked:border-blue-500 peer-checked:bg-blue-50">
-                            <div class="payment-option-content">
-                                <div class="payment-option-icon">
-                                    <span class="material-icons text-blue-600">account_balance</span>
-                                </div>
-                                <div class="payment-option-text">
-                                    <div class="payment-option-title">Transferencia</div>
-                                    <div class="payment-option-description">Bancolombia, Nequi</div>
-                                </div>
-                            </div>
-                        </div>
-                    </label>
-
-                    <!-- PSE -->
-                    <label class="radio-option">
-                        <input type="radio" name="payment_method" value="pse" 
-                               class="radio-option-input peer">
-                        <div class="payment-option-card peer-checked:border-purple-500 peer-checked:bg-purple-50">
-                            <div class="payment-option-content">
-                                <div class="payment-option-icon">
-                                    <span class="material-icons text-purple-600">credit_card</span>
-                                </div>
-                                <div class="payment-option-text">
-                                    <div class="payment-option-title">PSE</div>
-                                    <div class="payment-option-description">Pago seguro en línea</div>
-                                </div>
-                            </div>
-                        </div>
-                    </label>
+                    {% empty %}
+                    <p class="text-sm text-gray-600">No hay métodos de pago disponibles en este momento.</p>
+                    {% endfor %}
 
                     <!-- Información del método seleccionado -->
                     <div id="payment-info" class="mt-4 p-3 bg-gray-50 rounded-lg text-xs text-gray-600">
-                        <div id="cash-info">
-                            <p><strong>Efectivo:</strong> Paga al recibir tu pedido. Ten el monto exacto disponible.</p>
+                        {% for method in payment_methods %}
+                        <div data-payment-info="{{ method.value }}" style="display: none;">
+                            <p><strong>{{ method.label }}:</strong> {{ method.info }}</p>
                         </div>
-                        <div id="transfer-info" style="display: none;">
-                            <p><strong>Transferencia:</strong> Recibirás los datos bancarios por WhatsApp para completar el pago.</p>
-                        </div>
-                        <div id="pse-info" style="display: none;">
-                            <p><strong>PSE:</strong> Serás redirigido a la plataforma de tu banco para completar el pago.</p>
-                        </div>
+                        {% endfor %}
                     </div>
                 </div>
             </div>
@@ -206,8 +172,9 @@ document.addEventListener('DOMContentLoaded', function() {
 
         const selectedProducts = {{ selected_products|safe }};
         const settings = {
-            minimumOrder: {{ settings.minimum_order_amount|default:20000|floatformat:0 }},
-            freeDeliveryThreshold: {{ settings.free_delivery_threshold|default:50000|floatformat:0 }}
+            minimumOrder: Number('{{ settings.minimum_order_amount|default:20000|floatformat:0 }}'),
+            freeDeliveryThreshold: Number('{{ settings.free_delivery_threshold|default:50000|floatformat:0 }}'),
+            deliveryCost: Number('{{ settings.delivery_cost|default:0|floatformat:0 }}')
         };
 
         // Llenar información básica
@@ -308,18 +275,32 @@ document.addEventListener('DOMContentLoaded', function() {
 
     function setupPaymentMethodChange() {
         const radios = document.querySelectorAll('input[name="payment_method"]');
+        const infoSections = document.querySelectorAll('[data-payment-info]');
+
+        function hideAllPaymentInfos() {
+            infoSections.forEach(section => {
+                section.style.display = 'none';
+            });
+        }
+
         radios.forEach(radio => {
             radio.addEventListener('change', function() {
-                // Ocultar todas las infos
-                document.getElementById('cash-info').style.display = 'none';
-                document.getElementById('transfer-info').style.display = 'none';
-                document.getElementById('pse-info').style.display = 'none';
-                
-                // Mostrar la info correspondiente
-                document.getElementById(this.value + '-info').style.display = 'block';
-        
+                hideAllPaymentInfos();
+                const target = document.querySelector(`[data-payment-info="${this.value}"]`);
+                if (target) {
+                    target.style.display = 'block';
+                }
             });
         });
+
+        hideAllPaymentInfos();
+        const checked = document.querySelector('input[name="payment_method"]:checked');
+        if (checked) {
+            const defaultSection = document.querySelector(`[data-payment-info="${checked.value}"]`);
+            if (defaultSection) {
+                defaultSection.style.display = 'block';
+            }
+        }
     }
 
     function createHiddenInputs(orderInfo, selectedProducts, notes) {

--- a/project/orders/templates/orders/wompi_checkout.html
+++ b/project/orders/templates/orders/wompi_checkout.html
@@ -1,0 +1,206 @@
+{% extends "core/base_dashboard.html" %}
+{% load humanize %}
+
+{% block title %}Pagar con Wompi | Janay Pedidos{% endblock %}
+
+{% block main_content %}
+<div class="max-w-3xl mx-auto">
+    <div class="content-card">
+        <div class="content-header">
+            <h1 class="content-title">Completar pago con Wompi</h1>
+            <p class="content-description">Confirma el pago seguro de tu pedido sin salir de Janay.</p>
+        </div>
+
+        <div class="p-6 space-y-6">
+            <div class="bg-emerald-50 border border-emerald-200 rounded-xl p-4 flex items-start space-x-3">
+                <span class="material-icons text-emerald-600">lock</span>
+                <div>
+                    <p class="text-sm text-emerald-900">
+                        Te redirigiremos a la pasarela de Wompi para realizar el pago en línea. Al finalizar, volverás automáticamente a Janay.
+                    </p>
+                    {% if terms_link %}
+                        <p class="text-xs text-emerald-800 mt-2">
+                            Al continuar aceptas los <a href="{{ terms_link }}" class="text-emerald-700 underline" target="_blank" rel="noopener">términos y condiciones de Wompi</a>.
+                        </p>
+                    {% endif %}
+                </div>
+            </div>
+
+            <div class="border border-gray-200 rounded-xl p-4">
+                <h2 class="text-lg font-semibold text-gray-900 mb-4">Resumen del pedido</h2>
+                <dl class="space-y-2 text-sm text-gray-700">
+                    <div class="flex justify-between">
+                        <dt>Número de pedido:</dt>
+                        <dd class="font-medium">{{ order.order_number }}</dd>
+                    </div>
+                    <div class="flex justify-between">
+                        <dt>Cliente:</dt>
+                        <dd class="font-medium">{{ order.customer_name }}</dd>
+                    </div>
+                    <div class="flex justify-between">
+                        <dt>Total a pagar:</dt>
+                        <dd class="text-xl font-semibold text-orange-600">${{ order.total|intcomma }}</dd>
+                    </div>
+                </dl>
+            </div>
+
+            {% if acceptance_error %}
+                <div class="bg-red-50 border border-red-200 text-red-700 rounded-xl p-4">
+                    <p class="font-semibold">No pudimos iniciar el pago con Wompi.</p>
+                    <p class="text-sm mt-2">{{ acceptance_error }}</p>
+                    <p class="text-xs mt-2">Por favor intenta nuevamente en unos minutos o elige otro método de pago.</p>
+                </div>
+            {% endif %}
+        </div>
+
+        <div class="flex flex-col md:flex-row md:justify-between md:items-center border-t border-gray-200 p-4 md:p-6 space-y-3 md:space-y-0">
+            <a href="{% url 'orders:step3' %}" class="btn-step-cancel">
+                <span class="material-icons mr-2 text-sm">arrow_back</span>
+                Volver a mi pedido
+            </a>
+
+            <button id="wompi-pay-btn" class="btn-step-continue {% if acceptance_error %}opacity-50 cursor-not-allowed{% endif %}" {% if acceptance_error %}disabled{% endif %}>
+                Pagar con Wompi
+                <span class="material-icons ml-2 text-sm">payments</span>
+            </button>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block dashboard_js %}
+{{ block.super }}
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const payButton = document.getElementById('wompi-pay-btn');
+        if (!payButton || payButton.hasAttribute('disabled')) {
+            return;
+        }
+
+        const wompiScriptSources = JSON.parse('{{ widget_js_sources|escapejs }}');
+        let widgetReady = typeof WidgetCheckout !== 'undefined';
+        let loadedScriptUrl = widgetReady ? '{{ widget_js_url|escapejs }}' : null;
+
+        function markWidgetReady(scriptUrl) {
+            widgetReady = true;
+            loadedScriptUrl = scriptUrl;
+            console.info('Script de Wompi cargado correctamente:', scriptUrl);
+        }
+
+        function loadWompiScript(index) {
+            if (widgetReady) {
+                return;
+            }
+
+            if (!Array.isArray(wompiScriptSources) || wompiScriptSources.length === 0) {
+                console.error('No se configuraron URLs del widget de Wompi.');
+                return;
+            }
+
+            if (index >= wompiScriptSources.length) {
+                console.error('No fue posible cargar el script del widget de Wompi.');
+                return;
+            }
+
+            const scriptUrl = wompiScriptSources[index];
+            const scriptTag = document.createElement('script');
+            scriptTag.src = scriptUrl;
+            scriptTag.async = true;
+            scriptTag.onload = function() {
+                markWidgetReady(scriptUrl);
+            };
+            scriptTag.onerror = function() {
+                console.warn('Fallo al cargar el script de Wompi:', scriptUrl);
+                loadWompiScript(index + 1);
+            };
+            document.head.appendChild(scriptTag);
+        }
+
+        loadWompiScript(0);
+
+        const wompiConfig = {
+            currency: 'COP',
+            amountInCents: {{ amount_in_cents|default:0 }},
+            reference: '{{ reference|escapejs }}',
+            publicKey: '{{ public_key|escapejs }}',
+            redirectUrl: '{{ redirect_url|escapejs }}',
+            acceptanceToken: {% if acceptance_token %}'{{ acceptance_token|escapejs }}'{% else %}null{% endif %},
+            integritySignature: {% if integrity_signature %}'{{ integrity_signature|escapejs }}'{% else %}null{% endif %},
+            signaturePayload: {% if integrity_signature_payload %}'{{ integrity_signature_payload|escapejs }}'{% else %}null{% endif %},
+            formattedAmount: '{{ amount_formatted|default:"0.00"|escapejs }}',
+            customerEmail: {% if customer_email %}'{{ customer_email|escapejs }}'{% else %}null{% endif %},
+            customerFullName: {% if customer_name %}'{{ customer_name|escapejs }}'{% else %}null{% endif %},
+            customerPhone: {% if customer_phone %}'{{ customer_phone|escapejs }}'{% else %}null{% endif %},
+            customerPhonePrefix: {% if customer_phone_prefix %}'{{ customer_phone_prefix|escapejs }}'{% else %}null{% endif %},
+            customerPhoneRaw: {% if customer_phone_raw %}'{{ customer_phone_raw|escapejs }}'{% else %}null{% endif %}
+        };
+
+        console.log('Wompi checkout data', wompiConfig);
+
+        payButton.addEventListener('click', function(event) {
+            event.preventDefault();
+
+            try {
+                if (typeof WidgetCheckout === 'undefined') {
+                    const message = 'WidgetCheckout no está disponible. Verifica que el script de Wompi cargó correctamente.';
+                    console.error(message, { loadedScriptUrl });
+                    throw new Error(message);
+                }
+
+                const checkoutOptions = {
+                    currency: wompiConfig.currency,
+                    amountInCents: wompiConfig.amountInCents,
+                    reference: wompiConfig.reference,
+                    publicKey: wompiConfig.publicKey,
+                    redirectUrl: wompiConfig.redirectUrl,
+                };
+
+                if (wompiConfig.integritySignature) {
+                    checkoutOptions.signature = {
+                        integrity: wompiConfig.integritySignature
+                    };
+                }
+
+                if (wompiConfig.acceptanceToken) {
+                    checkoutOptions.acceptanceToken = wompiConfig.acceptanceToken;
+                }
+
+                const customerData = {};
+
+                if (wompiConfig.customerEmail) {
+                    customerData.email = wompiConfig.customerEmail;
+                }
+                if (wompiConfig.customerFullName) {
+                    customerData.fullName = wompiConfig.customerFullName;
+                }
+                if (wompiConfig.customerPhone && wompiConfig.customerPhonePrefix) {
+                    customerData.phoneNumber = wompiConfig.customerPhone;
+                    customerData.phoneNumberPrefix = wompiConfig.customerPhonePrefix;
+                } else if (wompiConfig.customerPhoneRaw) {
+                    console.warn('No se pudo derivar un prefijo válido para el teléfono del cliente.', {
+                        raw: wompiConfig.customerPhoneRaw,
+                        normalized: wompiConfig.customerPhone,
+                        prefix: wompiConfig.customerPhonePrefix,
+                    });
+                }
+
+                if (Object.keys(customerData).length > 0) {
+                    checkoutOptions.customerData = customerData;
+                }
+
+                const checkout = new WidgetCheckout(checkoutOptions);
+
+                checkout.open(function(result) {
+                    if (result && result.transaction && result.transaction.id) {
+                        const url = new URL('{{ redirect_url|escapejs }}');
+                        url.searchParams.set('transactionId', result.transaction.id);
+                        window.location.href = url.toString();
+                    }
+                });
+            } catch (error) {
+                console.error('Error al abrir el widget de Wompi', error);
+            }
+        });
+    });
+</script>
+{% endblock %}

--- a/project/orders/templates/orders/wompi_result.html
+++ b/project/orders/templates/orders/wompi_result.html
@@ -1,0 +1,104 @@
+{% extends "core/base_dashboard.html" %}
+{% load humanize %}
+
+{% block title %}Resultado del pago | Janay Pedidos{% endblock %}
+
+{% block main_content %}
+<div class="max-w-3xl mx-auto">
+    <div class="content-card">
+        <div class="content-header">
+            <h1 class="content-title">Estado del pago</h1>
+            <p class="content-description">Revisamos la información recibida desde Wompi.</p>
+        </div>
+
+        <div class="p-6 space-y-6">
+            {% if error_message %}
+                <div class="bg-red-50 border border-red-200 text-red-700 rounded-xl p-4">
+                    <p class="font-semibold">No pudimos confirmar el pago.</p>
+                    <p class="text-sm mt-2">{{ error_message }}</p>
+                    <p class="text-xs mt-2">Puedes intentar nuevamente desde la opción de pago o comunicarte con nosotros.</p>
+                </div>
+            {% else %}
+                <div class="rounded-xl p-4 border flex items-start space-x-3 {% if transaction_status == 'APPROVED' %}bg-emerald-50 border-emerald-200 text-emerald-900{% elif transaction_status == 'PENDING' %}bg-yellow-50 border-yellow-200 text-yellow-900{% else %}bg-gray-50 border-gray-200 text-gray-900{% endif %}">
+                    <span class="material-icons">
+                        {% if transaction_status == 'APPROVED' %}check_circle{% elif transaction_status == 'PENDING' %}hourglass_bottom{% else %}info{% endif %}
+                    </span>
+                    <div>
+                        <p class="text-base font-semibold">{{ transaction_status_label }}</p>
+                        {% if transaction_status == 'APPROVED' %}
+                            <p class="text-sm mt-1">Tu pago fue aprobado exitosamente. ¡Gracias por confiar en Janay!</p>
+                        {% elif transaction_status == 'PENDING' %}
+                            <p class="text-sm mt-1">El pago está en proceso de validación. Te notificaremos en cuanto recibamos la confirmación.</p>
+                        {% else %}
+                            <p class="text-sm mt-1">Recibimos una respuesta de Wompi con estado "{{ transaction_status_label }}".</p>
+                        {% endif %}
+                    </div>
+                </div>
+            {% endif %}
+
+            <div class="border border-gray-200 rounded-xl p-4">
+                <h2 class="text-lg font-semibold text-gray-900 mb-4">Resumen del pedido</h2>
+                <dl class="space-y-2 text-sm text-gray-700">
+                    <div class="flex justify-between">
+                        <dt>Pedido:</dt>
+                        <dd class="font-medium">{{ order.order_number }}</dd>
+                    </div>
+                    <div class="flex justify-between">
+                        <dt>Total:</dt>
+                        <dd class="font-semibold text-orange-600">${{ order.total|intcomma }}</dd>
+                    </div>
+                    <div class="flex justify-between">
+                        <dt>Estado del pago:</dt>
+                        <dd class="font-medium">{{ order.get_payment_status_display }}</dd>
+                    </div>
+                    {% if transaction_id %}
+                    <div class="flex justify-between">
+                        <dt>ID de transacción:</dt>
+                        <dd class="font-mono text-xs">{{ transaction_id }}</dd>
+                    </div>
+                    {% endif %}
+                </dl>
+            </div>
+
+            {% if transaction %}
+                <div class="border border-gray-200 rounded-xl p-4">
+                    <h2 class="text-lg font-semibold text-gray-900 mb-4">Información de la transacción</h2>
+                    <dl class="space-y-2 text-sm text-gray-700">
+                        {% if transaction.reference %}
+                        <div class="flex justify-between">
+                            <dt>Referencia:</dt>
+                            <dd class="font-medium">{{ transaction.reference }}</dd>
+                        </div>
+                        {% endif %}
+                        {% if transaction_amount %}
+                        <div class="flex justify-between">
+                            <dt>Monto reportado:</dt>
+                            <dd class="font-medium">${{ transaction_amount|intcomma }}</dd>
+                        </div>
+                        {% endif %}
+                        {% if transaction.payment_method_type %}
+                        <div class="flex justify-between">
+                            <dt>Método:</dt>
+                            <dd class="font-medium">{{ transaction.payment_method_type|title }}</dd>
+                        </div>
+                        {% endif %}
+                        {% if transaction.status_message %}
+                        <div class="flex justify-between">
+                            <dt>Mensaje:</dt>
+                            <dd class="font-medium text-sm text-gray-600">{{ transaction.status_message }}</dd>
+                        </div>
+                        {% endif %}
+                    </dl>
+                </div>
+            {% endif %}
+        </div>
+
+        <div class="flex justify-end border-t border-gray-200 p-4 md:p-6">
+            <a href="{% url 'orders:success' order.id %}" class="btn-step-continue">
+                Ver pedido confirmado
+                <span class="material-icons ml-2 text-sm">arrow_forward</span>
+            </a>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/project/orders/urls.py
+++ b/project/orders/urls.py
@@ -9,10 +9,13 @@ urlpatterns = [
     path('create/step1/', views.order_step1, name='step1'),
     path('create/step2/', views.order_step2, name='step2'),
     path('create/step3/', views.order_step3, name='step3'),
-    
+
     # Éxito de pedido
     path('success/<int:order_id>/', views.order_success, name='success'),
-    
+    path('payment/wompi/<int:order_id>/', views.wompi_checkout, name='wompi_checkout'),
+    path('payment/wompi/<int:order_id>/resultado/', views.wompi_result, name='wompi_result'),
+    path('payment/wompi/webhook/', views.wompi_webhook, name='wompi_webhook'),
+
     # Gestión del carrito
     path('cart/add/<int:product_id>/', views.add_to_cart, name='add_to_cart'),
     path('cart/remove/<int:product_id>/', views.remove_from_cart, name='remove_from_cart'),

--- a/project/orders/views.py
+++ b/project/orders/views.py
@@ -1,3 +1,9 @@
+from datetime import datetime, timedelta
+from decimal import Decimal
+import hashlib
+import json
+import traceback
+
 from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
@@ -5,13 +11,19 @@ from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.utils import timezone
 from django.urls import reverse
-from datetime import datetime, timedelta
-from decimal import Decimal
-import json
 from django.core.cache import cache
-import traceback
 
 from .models import Order, OrderItem, BusinessSettings
+from .services import (
+    WompiAPIError,
+    get_acceptance_information,
+    get_transaction_information,
+    get_wompi_base_url,
+    detect_wompi_key_environment,
+    normalize_wompi_key,
+    split_phone_number,
+    verify_event_signature,
+)
 from products.models import Product, Category
 
 @login_required
@@ -270,6 +282,61 @@ def order_step3(request):
     order_info = cart_data.get('order_info', {})
     selected_products = cart_data.get('selected_products', {})
     order_notes = cart_data.get('order_notes', '')
+    settings_obj = BusinessSettings.get_settings()
+
+    payment_details = {
+        'cash': {
+            'icon': 'payments',
+            'card_classes': 'peer-checked:border-green-500 peer-checked:bg-green-50',
+            'icon_classes': 'text-green-600',
+            'description': 'Pago al recibir',
+            'info': 'Paga al recibir tu pedido. Ten el monto exacto disponible.',
+        },
+        'wompi': {
+            'icon': 'payments',
+            'card_classes': 'peer-checked:border-emerald-500 peer-checked:bg-emerald-50',
+            'icon_classes': 'text-emerald-600',
+            'description': 'Pagos en línea seguros',
+            'info': 'Completa el pago en línea sin salir de Janay mediante la pasarela de Wompi.',
+        },
+    }
+
+    available_payment_methods = []
+    for value, label in Order.PAYMENT_METHOD:
+        is_enabled = False
+        if value == 'cash':
+            is_enabled = settings_obj.accept_cash
+        elif value == 'wompi':
+            is_enabled = bool(settings_obj.accept_wompi and settings_obj.wompi_public_key)
+
+        if not is_enabled:
+            continue
+
+        details = payment_details.get(value, {})
+        available_payment_methods.append({
+            'value': value,
+            'label': label,
+            'icon': details.get('icon', 'payments'),
+            'card_classes': details.get('card_classes', 'peer-checked:border-blue-500 peer-checked:bg-blue-50'),
+            'icon_classes': details.get('icon_classes', 'text-blue-600'),
+            'description': details.get('description', 'Método de pago disponible'),
+            'info': details.get('info', 'Selecciona esta opción para continuar.'),
+        })
+
+    if not available_payment_methods:
+        available_payment_methods.append({
+            'value': 'cash',
+            'label': dict(Order.PAYMENT_METHOD).get('cash', 'Efectivo'),
+            'icon': 'payments',
+            'card_classes': 'peer-checked:border-green-500 peer-checked:bg-green-50',
+            'icon_classes': 'text-green-600',
+            'description': 'Pago al recibir',
+            'info': 'Paga al recibir tu pedido. Ten el monto exacto disponible.',
+        })
+
+    default_payment_method = cart_data.get('payment_method')
+    if default_payment_method not in {method['value'] for method in available_payment_methods}:
+        default_payment_method = available_payment_methods[0]['value']
     
     # Verificación adicional de seguridad
     if not selected_products:
@@ -278,33 +345,70 @@ def order_step3(request):
     
     if request.method == 'POST':
         # Crear el pedido
-        payment_method = request.POST.get('payment_method', 'cash')
-        final_order_notes = request.POST.get('order_notes', order_notes)       
+        payment_method = request.POST.get('payment_method', default_payment_method)
+        valid_methods = {method['value'] for method in available_payment_methods}
+        if payment_method not in valid_methods:
+            messages.error(request, "El método de pago seleccionado no está disponible.")
+            return redirect('orders:step3')
+
+        cart_data['payment_method'] = payment_method
+        request.session['order_cart'] = cart_data
+        request.session.modified = True
+
+        final_order_notes = request.POST.get('order_notes', order_notes)
         try:
-            # Crear el pedido
-            order = Order.objects.create(
-                user=request.user,
-                delivery_type=order_info.get('delivery_type', 'pickup'),
-                customer_name=order_info.get('customer_name', ''),
-                customer_phone=order_info.get('customer_phone', ''),
-                customer_email=order_info.get('customer_email', ''),
-                desired_date=datetime.strptime(order_info.get('desired_date'), '%Y-%m-%d').date(),
-                desired_time=datetime.strptime(order_info.get('desired_time'), '%H:%M').time(),
-                delivery_address=order_info.get('delivery_address', ''),
-                delivery_neighborhood=order_info.get('delivery_neighborhood', ''),
-                delivery_references=order_info.get('delivery_references', ''),
-                payment_method=payment_method,
-                notes=final_order_notes,  # CAMBIAR 'special_instructions' por 'notes'
-                status='pending'
-            )
-            
+            desired_date = datetime.strptime(order_info.get('desired_date'), '%Y-%m-%d').date()
+            desired_time = datetime.strptime(order_info.get('desired_time'), '%H:%M').time()
+
+            order = None
+            pending_order_id = request.session.get('wompi_pending_order_id')
+            if pending_order_id:
+                try:
+                    order = Order.objects.get(id=pending_order_id, user=request.user)
+                except Order.DoesNotExist:
+                    request.session.pop('wompi_pending_order_id', None)
+                    order = None
+
+            if order:
+                order.items.all().delete()
+                order.delivery_type = order_info.get('delivery_type', 'pickup')
+                order.customer_name = order_info.get('customer_name', '')
+                order.customer_phone = order_info.get('customer_phone', '')
+                order.customer_email = order_info.get('customer_email', '')
+                order.desired_date = desired_date
+                order.desired_time = desired_time
+                order.delivery_address = order_info.get('delivery_address', '')
+                order.delivery_neighborhood = order_info.get('delivery_neighborhood', '')
+                order.delivery_references = order_info.get('delivery_references', '')
+                order.payment_method = payment_method
+                order.notes = final_order_notes
+                order.status = 'pending'
+                order.payment_status = 'pending'
+                order.payment_reference = ''
+                order.save()
+            else:
+                order = Order.objects.create(
+                    user=request.user,
+                    delivery_type=order_info.get('delivery_type', 'pickup'),
+                    customer_name=order_info.get('customer_name', ''),
+                    customer_phone=order_info.get('customer_phone', ''),
+                    customer_email=order_info.get('customer_email', ''),
+                    desired_date=desired_date,
+                    desired_time=desired_time,
+                    delivery_address=order_info.get('delivery_address', ''),
+                    delivery_neighborhood=order_info.get('delivery_neighborhood', ''),
+                    delivery_references=order_info.get('delivery_references', ''),
+                    payment_method=payment_method,
+                    notes=final_order_notes,
+                    status='pending'
+                )
+
             # Crear los items del pedido CON LAS CANTIDADES CORRECTAS
-            total_amount = 0
             for product_id, quantity in selected_products.items():
                 try:
                     product = Product.objects.get(id=product_id)
                     quantity = int(quantity)  # Asegurar que sea entero
-                    
+
                     OrderItem.objects.create(
                         order=order,
                         product=product,
@@ -312,36 +416,25 @@ def order_step3(request):
                         unit_price=product.price,
                         total_price=product.price * quantity
                     )
-                    
-                    total_amount += product.price * quantity
-                    
+
                 except Product.DoesNotExist:
                     continue
-            
-            # Calcular envío BASADO EN EL TIPO DE ENTREGA
-            settings = BusinessSettings.get_settings()
-            shipping_cost = 0
-            
-            # Solo aplicar costo de envío si es delivery
-            if order_info.get('delivery_type') == 'delivery':
-                shipping_cost = 0 if total_amount >= settings.free_delivery_threshold else settings.delivery_cost
-            
-            # Actualizar totales del pedido
-            order.subtotal = total_amount
-            order.shipping_cost = shipping_cost
-            order.total_amount = total_amount + shipping_cost
-            order.save()
-            # Limpiar sesión
+
+            # Asegurar que los totales se calculen correctamente
+            order.refresh_from_db()
+            messages.success(request, f"¡Pedido #{order.id} creado exitosamente!")
+
+            if payment_method == 'wompi':
+                request.session['wompi_pending_order_id'] = order.id
+                request.session.modified = True
+                return redirect('orders:wompi_checkout', order_id=order.id)
+
+            request.session.pop('wompi_pending_order_id', None)
             if 'order_cart' in request.session:
                 del request.session['order_cart']
-            
-            messages.success(request, f"¡Pedido #{order.id} creado exitosamente!")
-            
-            # Si el método de pago es efectivo, redirigir a la página de éxito
-            if payment_method == 'cash':
-                return redirect('orders:success', order_id=order.id)
-            else:
-                return redirect('orders:order_detail', order_id=order.id)
+            request.session.modified = True
+
+            return redirect('orders:success', order_id=order.id)
         
         except Exception as e:
             traceback.print_exc()
@@ -371,8 +464,10 @@ def order_step3(request):
         'selected_products': json.dumps(selected_products),
         'products_data': json.dumps(products_data),
         'order_notes': order_notes,
-        'settings': BusinessSettings.get_settings(),
-        
+        'settings': settings_obj,
+        'payment_methods': available_payment_methods,
+        'default_payment_method': default_payment_method,
+
         # Datos para el template base de steps
         'step_number': 3,
         'current_step': 3,
@@ -386,7 +481,241 @@ def order_step3(request):
     return render(request, 'orders/step3.html', context)
 
 
+@login_required
+def wompi_checkout(request, order_id):
+    """Pantalla intermedia para iniciar el pago con Wompi."""
+
+    order = get_object_or_404(Order, id=order_id, user=request.user)
+    settings_obj = BusinessSettings.get_settings()
+
+    if not (settings_obj.accept_wompi and settings_obj.wompi_public_key):
+        messages.error(request, 'Los pagos con Wompi no están configurados actualmente.')
+        return redirect('orders:success', order_id=order.id)
+
+    env = get_wompi_base_url(settings_obj.wompi_environment)
+    acceptance_data = {}
+    acceptance_error = None
+    acceptance_token = None
+    terms_link = None
+
+    public_key = normalize_wompi_key(settings_obj.wompi_public_key)
+    private_key = normalize_wompi_key(settings_obj.wompi_private_key)
+    integrity_key = normalize_wompi_key(settings_obj.wompi_integrity_key)
+    event_key = normalize_wompi_key(settings_obj.wompi_event_key)
+
+    key_mismatch_errors = []
+    for label, key in (
+        ('llave pública', public_key),
+        ('llave privada', private_key),
+        ('llave de integridad', integrity_key),
+        ('llave de eventos', event_key),
+    ):
+        key_environment = detect_wompi_key_environment(key)
+        if key_environment and key_environment != settings_obj.wompi_environment:
+            key_mismatch_errors.append(
+                (
+                    f"La {label} parece corresponder al entorno "
+                    f"{key_environment.upper()}, pero la configuración actual de Wompi "
+                    f"está en {settings_obj.wompi_environment.upper()}. Revisa las llaves en "
+                    'https://docs.wompi.co/docs/colombia/ambientes-y-llaves '
+                    'para evitar respuestas 422 del API.'
+                )
+            )
+
+    if key_mismatch_errors:
+        acceptance_error = ' '.join(key_mismatch_errors)
+    else:
+        try:
+            acceptance_data = get_acceptance_information(
+                public_key,
+                settings_obj.wompi_environment,
+            )
+        except WompiAPIError as exc:
+            acceptance_error = str(exc)
+        else:
+            presigned = acceptance_data.get('presigned_acceptance') or {}
+            acceptance_token = presigned.get('acceptance_token') or None
+            terms_link = presigned.get('permalink')
+            if not acceptance_token and not acceptance_error:
+                acceptance_error = (
+                    'No fue posible obtener el token de aceptación de Wompi. '
+                    'Por favor intenta nuevamente en unos minutos.'
+                )
+
+    order.refresh_from_db()
+    total_amount = (order.total or Decimal('0')).quantize(Decimal('0.01'))
+    amount_in_cents = int(total_amount * Decimal('100'))
+    reference = (order.order_number or '').strip()
+
+    redirect_url = request.build_absolute_uri(
+        reverse('orders:wompi_result', args=[order.id])
+    )
+
+    integrity_signature = None
+    signature_payload = None
+    if integrity_key and amount_in_cents:
+        signature_payload = f"{reference}{amount_in_cents}COP{integrity_key}"
+        integrity_signature = hashlib.sha256(signature_payload.encode('utf-8')).hexdigest()
+
+    customer_phone_raw = (order.customer_phone or '').strip()
+    phone_prefix, phone_number = split_phone_number(customer_phone_raw)
+
+    context = {
+        'order': order,
+        'settings': settings_obj,
+        'environment': env,
+        'widget_js_url': env.widget_js_url,
+        'widget_js_sources': json.dumps(env.widget_js_urls),
+        'amount_in_cents': amount_in_cents,
+        'amount_formatted': f"{total_amount:.2f}",
+        'reference': reference,
+        'public_key': public_key,
+        'redirect_url': redirect_url,
+        'acceptance_data': acceptance_data,
+        'acceptance_error': acceptance_error,
+        'acceptance_token': acceptance_token,
+        'terms_link': terms_link,
+        'integrity_signature': integrity_signature,
+        'integrity_signature_payload': signature_payload,
+        'customer_email': (order.customer_email or '').strip(),
+        'customer_phone': phone_number,
+        'customer_phone_prefix': phone_prefix,
+        'customer_phone_raw': customer_phone_raw,
+        'customer_name': (order.customer_name or '').strip(),
+    }
+
+    return render(request, 'orders/wompi_checkout.html', context)
+
+
+@login_required
+def wompi_result(request, order_id):
+    """Vista de resultado a la que redirige Wompi tras el pago."""
+
+    order = get_object_or_404(Order, id=order_id, user=request.user)
+    settings_obj = BusinessSettings.get_settings()
+
+    transaction_id = (
+        request.GET.get('id')
+        or request.GET.get('transactionId')
+        or request.GET.get('transaction_id')
+    )
+
+    transaction_data = {}
+    transaction_status = None
+    transaction_amount = None
+    error_message = None
+
+    if transaction_id:
+        public_key = normalize_wompi_key(settings_obj.wompi_public_key)
+        private_key = normalize_wompi_key(settings_obj.wompi_private_key)
+        try:
+            transaction_data = get_transaction_information(
+                transaction_id,
+                settings_obj.wompi_environment,
+                public_key=public_key,
+                private_key=private_key,
+            )
+            transaction_status = transaction_data.get('status')
+            amount_in_cents = transaction_data.get('amount_in_cents')
+            if amount_in_cents is not None:
+                transaction_amount = Decimal(amount_in_cents) / Decimal('100')
+
+            order.payment_reference = transaction_id
+            if transaction_status == 'APPROVED':
+                order.payment_status = 'confirmed'
+            elif transaction_status in {'DECLINED', 'ERROR', 'VOIDED'}:
+                order.payment_status = 'cancelled'
+            else:
+                order.payment_status = 'pending'
+
+            order.save(update_fields=['payment_status', 'payment_reference', 'updated_at'])
+        except WompiAPIError as exc:
+            error_message = str(exc)
+    else:
+        error_message = 'No recibimos información de la transacción desde Wompi.'
+
+    status_labels = {
+        'APPROVED': 'Aprobada',
+        'DECLINED': 'Rechazada',
+        'ERROR': 'Error',
+        'PENDING': 'Pendiente',
+        'VOIDED': 'Anulada',
+    }
+
+    if transaction_status == 'APPROVED':
+        request.session.pop('order_cart', None)
+        request.session.pop('wompi_pending_order_id', None)
+        request.session.modified = True
+
+    context = {
+        'order': order,
+        'transaction_id': transaction_id,
+        'transaction': transaction_data,
+        'transaction_status': transaction_status,
+        'transaction_status_label': status_labels.get(transaction_status, 'Desconocido'),
+        'transaction_amount': transaction_amount,
+        'error_message': error_message,
+    }
+
+    return render(request, 'orders/wompi_result.html', context)
+
+
 # Añadir esta nueva función después de order_detail
+@csrf_exempt
+def wompi_webhook(request):
+    """Recibe eventos firmados de Wompi para sincronizar el pedido."""
+
+    if request.method != 'POST':
+        return JsonResponse({'detail': 'Método no permitido'}, status=405)
+
+    settings_obj = BusinessSettings.get_settings()
+    event_key = normalize_wompi_key(settings_obj.wompi_event_key)
+    if not event_key:
+        return JsonResponse({'detail': 'Llave de eventos no configurada'}, status=400)
+
+    payload = request.body or b''
+    signature = request.headers.get('X-Event-Signature') or request.META.get('HTTP_X_EVENT_SIGNATURE', '')
+    if not verify_event_signature(event_key, payload, signature):
+        return JsonResponse({'detail': 'Firma inválida'}, status=400)
+
+    try:
+        event_payload = json.loads(payload.decode('utf-8'))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return JsonResponse({'detail': 'Contenido inválido'}, status=400)
+
+    transaction_data = (event_payload.get('data') or {}).get('transaction') or {}
+    transaction_id = transaction_data.get('id')
+    reference = transaction_data.get('reference')
+
+    order = None
+    if transaction_id:
+        order = Order.objects.filter(payment_reference=transaction_id).first()
+    if order is None and reference:
+        order = Order.objects.filter(order_number=reference).first()
+
+    if order is None:
+        return JsonResponse({'received': True, 'detail': 'Orden no encontrada'}, status=200)
+
+    status = (transaction_data.get('status') or '').upper()
+    status_map = {
+        'APPROVED': 'confirmed',
+        'DECLINED': 'cancelled',
+        'ERROR': 'cancelled',
+        'VOIDED': 'cancelled',
+        'PENDING': 'pending',
+    }
+
+    mapped_status = status_map.get(status)
+    if mapped_status:
+        order.payment_status = mapped_status
+    if transaction_id:
+        order.payment_reference = transaction_id
+
+    order.save(update_fields=['payment_status', 'payment_reference', 'updated_at'])
+
+    return JsonResponse({'received': True})
+
+
 @login_required
 def order_success(request, order_id):
     """Vista de éxito después de confirmar un pedido"""


### PR DESCRIPTION
## Summary
- add storage for the Wompi events key and expose it in the business settings admin
- validate key environments before launching the widget and surface actionable guidance when the API returns 422 errors
- verify webhook signatures with the events key and update orders as Wompi sends transaction status events

## Testing
- `python -m compileall project/orders`


------
https://chatgpt.com/codex/tasks/task_e_68d879165a388330b6bd18f2504e8b0f